### PR TITLE
ci: auto-publish dx616b/spoti-to-navidrome on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Extract version from git tags
         id: version
         run: echo "VERSION=$(git describe --tags --always | cut -d'-' -f1)" >> "$GITHUB_OUTPUT"
-    
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
@@ -28,17 +28,15 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           annotations: |
-            type=org.opencontainers.image.description, value=Download your Spotify playlists and songs along with album art and metadata in a self-hosted way via Docker.
-            type=org.opencontainers.image.url, value=https://github.com/henriquesebastiao/downtify
-            type=org.opencontainers.image.source, value=https://github.com/henriquesebastiao/downtify
+            type=org.opencontainers.image.description, value=Self-hosted Spotify downloader with slskd and Navidrome sync (dx616b fork).
+            type=org.opencontainers.image.url, value=https://github.com/dx616b/downtify
+            type=org.opencontainers.image.source, value=https://github.com/dx616b/downtify
             type=org.opencontainers.image.version, value=${{ steps.version.outputs.VERSION }}
-            type=org.opencontainers.image.authors, value=Henrique Sebastião <contato@henriquesebastiao.com>
             type=org.opencontainers.image.licenses, value=GPL-3.0
-            type=org.opencontainers.image.vendor, value=Henrique Sebastião
             type=org.opencontainers.image.base.name, value=python:3.13-alpine
             type=org.opencontainers.image.title, value=Downtify
-    
-      - name: Login to DockerHub
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -58,8 +56,8 @@ jobs:
           context: .
           push: true
           tags: |
-            henriquesebastiao/downtify:latest
-            henriquesebastiao/downtify:${{ steps.version.outputs.VERSION }}
+            dx616b/spoti-to-navidrome:latest
+            dx616b/spoti-to-navidrome:${{ steps.version.outputs.VERSION }}
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-hub-fork.yml
+++ b/.github/workflows/docker-hub-fork.yml
@@ -1,0 +1,45 @@
+# Build and push dx616b/spoti-to-navidrome on main (fork deploy image).
+name: Docker Hub (fork)
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: dx616b/spoti-to-navidrome
+          tags: |
+            type=raw,value=latest,enable={{ github.ref == 'refs/heads/main' }}
+            type=raw,value=slskd-dev
+            type=sha,prefix=,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -67,7 +67,16 @@ This fork extends upstream Downtify v2.8.0 with Soulseek + Navidrome integration
 docker pull dx616b/spoti-to-navidrome:latest
 ```
 
-Tags: `latest` · `slskd-dev` (same build).
+Tags: `latest` · `slskd-dev` · short git SHA (from CI).
+
+**CI (GitHub Actions):** every push to `main` runs [Docker Hub (fork)](.github/workflows/docker-hub-fork.yml) and publishes multi-arch images. Add these repository secrets under **Settings → Secrets → Actions**:
+
+| Secret | Value |
+|--------|--------|
+| `DOCKERHUB_USERNAME` | `dx616b` |
+| `DOCKERHUB_TOKEN` | Docker Hub access token (Read & Write) |
+
+Publishing a GitHub **Release** also runs [build.yml](.github/workflows/build.yml) with version tags.
 
 ### What’s new
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docker-hub-fork.yml` — builds and pushes `dx616b/spoti-to-navidrome` on every push to `main` (tags: `latest`, `slskd-dev`, short SHA; amd64 + arm64)
- Updates `build.yml` release workflow to publish the fork image instead of `henriquesebastiao/downtify`
- Documents required GitHub secrets in README

## Setup (one-time)

Repo **Settings → Secrets → Actions**:

| Secret | Value |
|--------|--------|
| `DOCKERHUB_USERNAME` | `dx616b` |
| `DOCKERHUB_TOKEN` | Docker Hub token (Read & Write) |

## Test plan

- [ ] Merge PR
- [ ] Confirm **Docker Hub (fork)** workflow runs on `main`
- [ ] `docker pull dx616b/spoti-to-navidrome:latest` on server


Made with [Cursor](https://cursor.com)