### PR TITLE
ci: fix Documentation workflow Pages enablement

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,21 +1,31 @@
 name: Documentation
+
 on:
   push:
     branches:
       - master
       - main
+  workflow_dispatch:
+
 permissions:
   contents: read
   pages: write
   id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   deploy:
     environment:
-      name: docs
+      name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/configure-pages@v6
+        with:
+          enablement: true
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary

Fixes failed `Documentation` workflow on push to `main`:

```
Get Pages site failed ... Not Found
```

- `configure-pages@v6` with `enablement: true` (auto-enables Pages when allowed)
- Standard `github-pages` deployment environment
- `workflow_dispatch` for manual doc deploys
- Pages concurrency group

## Test plan

- [ ] Merge PR
- [ ] Documentation workflow passes on `main`
- [ ] Optional: confirm site at `https://dx616b.github.io/downtify/` (if public)

If it still fails, enable manually: **Settings → Pages → Build and deployment → GitHub Actions**.


Made with [Cursor](https://cursor.com)