### PR TITLE
ci: fix Docker Hub metadata tag parse error

### DIFF
--- a/.github/workflows/docker-hub-fork.yml
+++ b/.github/workflows/docker-hub-fork.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           images: dx616b/spoti-to-navidrome
           tags: |
-            type=raw,value=latest,enable={{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest
             type=raw,value=slskd-dev
             type=sha,prefix=,format=short
 


### PR DESCRIPTION
## Summary

Fixes `docker/metadata-action@v6` failure:

```
Parse error on line 1: {{ github.ref == 'refs/heads/main'
```

The `enable` field uses metadata-action Handlebars syntax, not GitHub Actions `${{ }}`. The `==` comparison is invalid there.

Removed the redundant `enable` clause — `docker-hub-fork.yml` already triggers only on `main`.

## Test plan

- [ ] Merge PR
- [ ] Docker Hub (fork) workflow completes and pushes `latest`, `slskd-dev`, and short SHA tags


Made with [Cursor](https://cursor.com)