### PR TITLE
chore: assign Dependabot PRs to dx616b

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,27 +5,27 @@ updates:
     schedule:
       interval: "daily"
     assignees:
-      - "henriquesebastiao"
+      - "dx616b"
 
   - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:
       interval: "daily"
     assignees:
-      - "henriquesebastiao"
+      - "dx616b"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
     assignees:
-      - "henriquesebastiao"
+      - "dx616b"
 
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "daily"
     assignees:
-      - "henriquesebastiao"
+      - "dx616b"
     exclude-paths:
-       - "requirements.txt"
+      - "requirements.txt"


### PR DESCRIPTION
## Summary

Updates `.github/dependabot.yml` so all Dependabot PRs assign to **dx616b** instead of upstream maintainer.

Covers: GitHub Actions, docker-compose, Docker, and uv.

## Enable on fork (one-time, in GitHub UI)

The config file alone is not enough on forks. After merging:

1. **Settings → Code security and analysis** (or **Advanced Security**)
2. Enable **Dependabot alerts**
3. Enable **Dependabot security updates** (optional but recommended)
4. Enable **Dependabot version updates**

Dependabot should then open daily PRs on this repo.

## Test plan

- [ ] Merge PR
- [ ] Enable the three Dependabot toggles in repo Settings
- [ ] Within a few days, confirm Dependabot PRs appear and assign to dx616b


Made with [Cursor](https://cursor.com)