### PR TITLE
ci: drop slskd-dev Docker tag

### DIFF
--- a/.github/workflows/docker-hub-fork.yml
+++ b/.github/workflows/docker-hub-fork.yml
@@ -37,7 +37,6 @@ jobs:
             type=org.opencontainers.image.documentation,value=https://github.com/dx616b/downtify#readme
           tags: |
             type=raw,value=latest
-            type=raw,value=slskd-dev
             type=sha,prefix=,format=short
 
       - name: Build and push


### PR DESCRIPTION
## Summary
- Remove `slskd-dev` from Docker Hub publish tags
- Keep `latest` and short git SHA only


Made with [Cursor](https://cursor.com)