### PR TITLE
Improve app responsiveness with async I/O and paginated library

### DIFF
--- a/downtify/api.py
+++ b/downtify/api.py
@@ -26,6 +26,7 @@ import asyncio
 import contextlib
 import json
 import re
+import time
 from pathlib import Path
 from typing import Any, Optional
 
@@ -56,7 +57,10 @@ from .library_delete import (
 )
 from .library_metadata_cache import LibraryMetadataCache
 from .library_paths import locate_library_file, slskd_dir_from_downloader
-from .library_paths_cache import invalidate_library_paths_cache
+from .library_paths_cache import (
+    invalidate_library_paths_cache,
+    register_paths_change_listener,
+)
 from .library_reconcile import (
     playlist_refresh_enabled,
     reconcile_and_refresh,
@@ -722,8 +726,7 @@ def check_update() -> Optional[dict[str, Any]]:
     return None
 
 
-@router.get('/api/songs/search')
-def search_endpoint(query: str = Query('')) -> list[dict[str, Any]]:
+def _search_songs(query: str) -> list[dict[str, Any]]:
     results = providers.search_songs(query, limit=20)
     if results:
         return results
@@ -745,14 +748,19 @@ def search_endpoint(query: str = Query('')) -> list[dict[str, Any]]:
     return []
 
 
+@router.get('/api/songs/search')
+async def search_endpoint(query: str = Query('')) -> list[dict[str, Any]]:
+    return await asyncio.to_thread(_search_songs, query)
+
+
 @router.get('/api/song/url')
-def song_url_endpoint(url: str = Query(...)):
-    return _resolve_url(url)
+async def song_url_endpoint(url: str = Query(...)):
+    return await asyncio.to_thread(_resolve_url, url)
 
 
 @router.get('/api/url')
-def url_endpoint(url: str = Query(...)):
-    return _resolve_url(url)
+async def url_endpoint(url: str = Query(...)):
+    return await asyncio.to_thread(_resolve_url, url)
 
 
 def _resolve_url(url: str):
@@ -1209,7 +1217,9 @@ async def _sync_playlist_navidrome(
             state.settings,
             navidrome_index=state.navidrome_index,
             download_dir=download_dir,
-            delete_tag_mismatches=tag_mismatch_delete_context_from_state(state),
+            delete_tag_mismatches=tag_mismatch_delete_context_from_state(
+                state
+            ),
         )
     except Exception:
         logger.exception(
@@ -1835,6 +1845,15 @@ def _report_for_spotify_playlist(
     return report
 
 
+_BATCH_REPORTS_CACHE: tuple[float, list[dict[str, Any]]] | None = None
+_BATCH_REPORTS_CACHE_TTL_SECONDS = 30.0
+
+
+def invalidate_playlist_batch_reports_cache() -> None:
+    global _BATCH_REPORTS_CACHE
+    _BATCH_REPORTS_CACHE = None
+
+
 def _build_playlist_batch_reports(
     *,
     include_tracks: bool = False,
@@ -1869,6 +1888,24 @@ def _build_playlist_batch_reports(
         )
     )
     _attach_monitor_state(reports)
+    return reports
+
+
+def _build_playlist_batch_reports_cached(
+    *,
+    include_tracks: bool = False,
+) -> list[dict[str, Any]]:
+    global _BATCH_REPORTS_CACHE
+    if include_tracks:
+        return _build_playlist_batch_reports(include_tracks=True)
+    now = time.monotonic()
+    if (
+        _BATCH_REPORTS_CACHE is not None
+        and now - _BATCH_REPORTS_CACHE[0] < _BATCH_REPORTS_CACHE_TTL_SECONDS
+    ):
+        return _BATCH_REPORTS_CACHE[1]
+    reports = _build_playlist_batch_reports(include_tracks=False)
+    _BATCH_REPORTS_CACHE = (now, reports)
     return reports
 
 
@@ -1967,10 +2004,13 @@ async def queue_missing_playlist_tracks(
         raise ValueError('spotify_playlist_id required')
 
     resolved_url = str(playlist_url or '').strip()
-    playlist_name, fetched_url, missing, expected_count = (
-        await asyncio.to_thread(
-            _missing_tracks_for_playlist, sid, refresh=refresh
-        )
+    (
+        playlist_name,
+        fetched_url,
+        missing,
+        expected_count,
+    ) = await asyncio.to_thread(
+        _missing_tracks_for_playlist, sid, refresh=refresh
     )
     if not resolved_url:
         resolved_url = fetched_url
@@ -2267,7 +2307,7 @@ async def download_batch_endpoint(request: Request) -> dict[str, Any]:
 async def list_playlist_batches_endpoint() -> dict[str, Any]:
     """Tracked Spotify playlist batches (summary from Spotify cache)."""
 
-    reports = await asyncio.to_thread(_build_playlist_batch_reports)
+    reports = await asyncio.to_thread(_build_playlist_batch_reports_cached)
     return {'playlists': reports, 'count': len(reports)}
 
 
@@ -2798,11 +2838,7 @@ def _monitor_schedule_kwargs(
         'check_at_minutes': check_at_minutes,
         'check_timezone': check_timezone,
     }
-    if enabled and (
-        reschedule
-        or not was_enabled
-        or last_checked is None
-    ):
+    if enabled and (reschedule or not was_enabled or last_checked is None):
         kwargs['last_checked'] = schedule_anchor_iso(
             interval_minutes,
             check_at_minutes,
@@ -2937,7 +2973,9 @@ async def update_monitor_playlist(
         payload, interval_minutes, existing
     )
 
-    enabled = bool(payload['enabled']) if 'enabled' in payload else existing.enabled
+    enabled = (
+        bool(payload['enabled']) if 'enabled' in payload else existing.enabled
+    )
     schedule_kwargs = _monitor_schedule_kwargs(
         enabled=enabled,
         interval_minutes=interval_minutes,
@@ -3004,3 +3042,6 @@ async def manual_check_playlist(playlist_id: int) -> dict[str, Any]:
 
     asyncio.create_task(_run())
     return {'status': 'check_started', 'id': playlist_id}
+
+
+register_paths_change_listener(invalidate_playlist_batch_reports_cache)

--- a/downtify/library_catalog.py
+++ b/downtify/library_catalog.py
@@ -103,7 +103,18 @@ def _register_path(
     )
 
 
-def _scan_library_paths(ctx: LibraryContext) -> list[str]:
+def bootstrap_library_paths(ctx: LibraryContext) -> list[str]:
+    """Fast path list from the track index (no full tree walk)."""
+
+    paths: set[str] = set()
+    if ctx.track_index is not None:
+        for stored in ctx.track_index.list_filenames():
+            if resolve_library_file(stored, ctx) is not None:
+                paths.add(stored)
+    return sorted(paths)
+
+
+def scan_library_paths(ctx: LibraryContext) -> list[str]:
     """Scan disk for playable paths (uncached)."""
 
     by_resolved: dict[str, str] = {}
@@ -137,7 +148,11 @@ def _scan_library_paths(ctx: LibraryContext) -> list[str]:
 def list_library_paths(ctx: LibraryContext) -> list[str]:
     """All playable library entries (download_dir + slskd tree + index)."""
 
-    return get_cached_paths(ctx, _scan_library_paths)
+    return get_cached_paths(
+        ctx,
+        scan_library_paths,
+        bootstrap_fn=bootstrap_library_paths,
+    )
 
 
 def _attach_playlists_to_entries(
@@ -170,14 +185,50 @@ def _attach_playlists_to_entries(
             entry['playlists'] = sorted(names)
 
 
-def list_library_entries(ctx: LibraryContext) -> list[dict[str, Any]]:
-    """Playable library rows with title/artist from embedded tags."""
-
+def _library_path_pairs(ctx: LibraryContext) -> list[tuple[str, Path]]:
     pairs: list[tuple[str, Path]] = []
     for stored in list_library_paths(ctx):
         full = resolve_library_file(stored, ctx)
         if full is not None:
             pairs.append((stored, full))
+    return pairs
+
+
+def _paths_for_playlist(
+    ctx: LibraryContext, playlist_name: str
+) -> Optional[set[str]]:
+    pl_name = str(playlist_name or '').strip()
+    if not pl_name or ctx.playlist_catalog is None:
+        return None
+    names = {
+        str(row.get('filename') or '').strip().replace('\\', '/')
+        for row in ctx.playlist_catalog.list_tracks(pl_name)
+    }
+    names.discard('')
+    return names
+
+
+def entry_matches_query(entry: dict[str, Any], query: str) -> bool:
+    q = str(query or '').strip().lower()
+    if not q:
+        return True
+    terms = [part for part in q.split() if part]
+    haystack = ' '.join([
+        str(entry.get('title') or ''),
+        str(entry.get('artist') or ''),
+        str(entry.get('album') or ''),
+        str(entry.get('file') or ''),
+        *[str(name) for name in (entry.get('playlists') or []) if name],
+    ]).lower()
+    return all(term in haystack for term in terms)
+
+
+def _entries_for_pairs(
+    ctx: LibraryContext,
+    pairs: list[tuple[str, Path]],
+) -> list[dict[str, Any]]:
+    if not pairs:
+        return []
     cache = ctx.metadata_cache
     if cache is not None:
         entries = cache.get_entries_batch(pairs)
@@ -188,3 +239,59 @@ def list_library_entries(ctx: LibraryContext) -> list[dict[str, Any]]:
     if ctx.playlist_catalog is not None and entries:
         _attach_playlists_to_entries(entries, pairs, ctx.playlist_catalog)
     return entries
+
+
+def list_library_entries(ctx: LibraryContext) -> list[dict[str, Any]]:
+    """Playable library rows with title/artist from embedded tags."""
+
+    return _entries_for_pairs(ctx, _library_path_pairs(ctx))
+
+
+def list_library_entries_page(
+    ctx: LibraryContext,
+    *,
+    page: int = 1,
+    limit: int = 25,
+    query: str = '',
+    playlist: str = '',
+) -> tuple[list[dict[str, Any]], int]:
+    """One page of library rows plus total count after filters."""
+
+    page_num = max(1, int(page))
+    page_size = max(1, min(200, int(limit)))
+    pairs = _library_path_pairs(ctx)
+    playlist_paths = _paths_for_playlist(ctx, playlist)
+    if playlist_paths is not None:
+        pairs = [
+            (stored, full)
+            for stored, full in pairs
+            if stored.replace('\\', '/') in playlist_paths
+        ]
+
+    q = str(query or '').strip()
+    if q and ctx.metadata_cache is not None:
+        allowed = {stored for stored, _full in pairs}
+        matched = ctx.metadata_cache.search_entries(
+            q, allowed_filenames=allowed
+        )
+        pair_by_file = {
+            stored.replace('\\', '/'): (stored, full) for stored, full in pairs
+        }
+        pairs = [
+            pair_by_file[name] for name in matched if name in pair_by_file
+        ]
+    elif q:
+        pairs = [
+            pair
+            for pair in pairs
+            if entry_matches_query(
+                {'file': pair[0]},
+                q,
+            )
+        ]
+
+    pairs.sort(key=lambda item: str(item[0]).lower())
+    total = len(pairs)
+    start = (page_num - 1) * page_size
+    page_pairs = pairs[start : start + page_size]
+    return _entries_for_pairs(ctx, page_pairs), total

--- a/downtify/library_metadata_cache.py
+++ b/downtify/library_metadata_cache.py
@@ -141,6 +141,61 @@ class LibraryMetadataCache:
             rows[0] if rows else library_entry_for_file(stored_path, full_path)
         )
 
+    def search_entries(
+        self,
+        query: str,
+        *,
+        allowed_filenames: Optional[set[str]] = None,
+    ) -> list[str]:
+        """Return stored paths matching *query* (all terms must match)."""
+
+        terms = [part.lower() for part in str(query or '').split() if part]
+        if not terms:
+            if allowed_filenames is None:
+                return []
+            return sorted(allowed_filenames)
+
+        allowed = None
+        if allowed_filenames is not None:
+            allowed = {
+                _norm_filename(name)
+                for name in allowed_filenames
+                if _norm_filename(name)
+            }
+
+        matched: list[str] = []
+        seen: set[str] = set()
+        with self._connect() as conn:
+            rows = conn.execute(
+                """SELECT filename, title, artist, album
+                   FROM library_metadata"""
+            ).fetchall()
+        for row in rows:
+            name = _norm_filename(str(row['filename']))
+            if not name or name in seen:
+                continue
+            if allowed is not None and name not in allowed:
+                continue
+            haystack = ' '.join([
+                str(row['title'] or ''),
+                str(row['artist'] or ''),
+                str(row['album'] or ''),
+                name,
+            ]).lower()
+            if all(term in haystack for term in terms):
+                matched.append(name)
+                seen.add(name)
+
+        if allowed is not None:
+            for name in allowed:
+                if name in seen:
+                    continue
+                if all(term in name.lower() for term in terms):
+                    matched.append(name)
+                    seen.add(name)
+
+        return sorted(matched)
+
     def get_entries_batch(
         self, items: list[tuple[str, Path]]
     ) -> list[dict[str, str]]:

--- a/downtify/library_paths_cache.py
+++ b/downtify/library_paths_cache.py
@@ -9,7 +9,10 @@ if TYPE_CHECKING:
     from .library_catalog import LibraryContext
 
 _PATH_CACHE: dict[str, tuple[float, list[str]]] = {}
-_CACHE_TTL_SECONDS = 90.0
+_RESCAN_PENDING: set[str] = set()
+_CACHE_TTL_SECONDS = 300.0
+_rescan_callback: object | None = None
+_change_listeners: list[object] = []
 
 
 def _cache_key(ctx: LibraryContext) -> str:
@@ -24,23 +27,72 @@ def _cache_key(ctx: LibraryContext) -> str:
     return '|'.join(parts)
 
 
+def set_cached_paths(ctx: LibraryContext, paths: list[str]) -> None:
+    """Store a scan result (background job or startup warm-up)."""
+
+    key = _cache_key(ctx)
+    _PATH_CACHE[key] = (time.monotonic(), list(paths))
+    _RESCAN_PENDING.discard(key)
+
+
+def paths_rescan_in_progress(ctx: LibraryContext) -> bool:
+    return _cache_key(ctx) in _RESCAN_PENDING
+
+
+def request_paths_rescan(ctx: LibraryContext) -> None:
+    """Mark cache stale; keep serving last snapshot until rescan completes."""
+
+    _RESCAN_PENDING.add(_cache_key(ctx))
+
+
 def get_cached_paths(
     ctx: LibraryContext,
     scan_fn,
+    *,
+    bootstrap_fn=None,
 ) -> list[str]:
-    """Return cached path list or run *scan_fn(ctx)* and store the result."""
+    """Return cached paths without blocking on a full disk walk."""
 
     key = _cache_key(ctx)
     now = time.monotonic()
     hit = _PATH_CACHE.get(key)
-    if hit is not None and now - hit[0] < _CACHE_TTL_SECONDS:
+    if hit is not None:
         return list(hit[1])
-    paths = scan_fn(ctx)
-    _PATH_CACHE[key] = (now, paths)
-    return paths
+
+    if bootstrap_fn is not None:
+        paths = bootstrap_fn(ctx)
+        if paths:
+            _PATH_CACHE[key] = (now, list(paths))
+            return list(paths)
+
+    return []
+
+
+def set_paths_rescan_callback(callback) -> None:
+    """Register a hook that schedules a background path scan."""
+
+    global _rescan_callback
+    _rescan_callback = callback
+
+
+def register_paths_change_listener(callback) -> None:
+    """Register hooks that run when library paths change."""
+
+    _change_listeners.append(callback)
 
 
 def invalidate_library_paths_cache() -> None:
     """Drop cached path lists (call after downloads, deletes, or path reconcile)."""
 
     _PATH_CACHE.clear()
+    _RESCAN_PENDING.clear()
+    if _rescan_callback is not None:
+        try:
+            _rescan_callback()
+        except Exception:
+            pass
+    for listener in _change_listeners:
+        try:
+            listener()
+        except Exception:
+            pass

--- a/downtify/library_paths_scanner.py
+++ b/downtify/library_paths_scanner.py
@@ -1,0 +1,79 @@
+"""Background filesystem scans for ``list_library_paths``."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Callable, Optional
+
+from loguru import logger
+
+from .library_paths_cache import (
+    paths_rescan_in_progress,
+    set_cached_paths,
+)
+
+if TYPE_CHECKING:
+    from .library_catalog import LibraryContext
+
+_SCAN_INTERVAL_SECONDS = 300.0
+_scan_tasks: dict[str, asyncio.Task[None]] = {}
+
+
+def _cache_key(ctx: LibraryContext) -> str:
+    parts = [str(ctx.download_dir.resolve())]
+    if ctx.slskd_dir is not None:
+        try:
+            parts.append(str(ctx.slskd_dir.resolve()))
+        except OSError:
+            parts.append(str(ctx.slskd_dir))
+    else:
+        parts.append('')
+    return '|'.join(parts)
+
+
+async def schedule_library_paths_rescan(
+    ctx: LibraryContext,
+    scan_fn: Callable[[LibraryContext], list[str]],
+) -> None:
+    """Run a full tree scan off the event loop and refresh the path cache."""
+
+    key = _cache_key(ctx)
+    existing = _scan_tasks.get(key)
+    if existing is not None and not existing.done():
+        return
+
+    async def _run() -> None:
+        try:
+            paths = await asyncio.to_thread(scan_fn, ctx)
+            set_cached_paths(ctx, paths)
+            logger.debug('Library path scan finished: {} path(s)', len(paths))
+        except Exception:
+            logger.exception('Background library path scan failed')
+        finally:
+            _scan_tasks.pop(key, None)
+
+    _scan_tasks[key] = asyncio.create_task(_run())
+
+
+async def library_paths_scan_loop(
+    get_ctx: Callable[[], Optional[LibraryContext]],
+    scan_fn: Callable[[LibraryContext], list[str]],
+    *,
+    interval_seconds: float = _SCAN_INTERVAL_SECONDS,
+) -> None:
+    """Periodically refresh the library path cache."""
+
+    while True:
+        await asyncio.sleep(interval_seconds)
+        ctx = get_ctx()
+        if ctx is None:
+            continue
+        await schedule_library_paths_rescan(ctx, scan_fn)
+
+
+def library_paths_scan_running(ctx: LibraryContext) -> bool:
+    key = _cache_key(ctx)
+    task = _scan_tasks.get(key)
+    if task is not None and not task.done():
+        return True
+    return paths_rescan_in_progress(ctx)

--- a/frontend/src/i18n/locales/en.js
+++ b/frontend/src/i18n/locales/en.js
@@ -167,6 +167,8 @@ export default {
       'Delete all tracks in "{name}"? Files on disk and the playlist catalog entry are removed. M3U and Navidrome sync run in the background.',
     playlistDeleted: 'Playlist "{name}" removed ({count} tracks).',
     playlistDeleteFailed: 'Could not delete playlist "{name}".',
+    pathsScanning:
+      'Scanning for new files in the background. The list may update shortly.',
   },
   monitor: {
     title: 'Playlist Monitor',

--- a/frontend/src/i18n/locales/es.js
+++ b/frontend/src/i18n/locales/es.js
@@ -172,6 +172,8 @@ export default {
       '¿Eliminar todas las pistas de "{name}"? Se quitan archivos y la entrada del catálogo. M3U y Navidrome se actualizan en segundo plano.',
     playlistDeleted: 'Lista "{name}" eliminada ({count} pistas).',
     playlistDeleteFailed: 'No se pudo eliminar la lista "{name}".',
+    pathsScanning:
+      'Buscando archivos nuevos en segundo plano. La lista puede actualizarse pronto.',
   },
   monitor: {
     title: 'Monitor de listas',

--- a/frontend/src/i18n/locales/pt-BR.js
+++ b/frontend/src/i18n/locales/pt-BR.js
@@ -169,6 +169,8 @@ export default {
       'Excluir todas as faixas de "{name}"? Remove arquivos e a entrada no catálogo. M3U e Navidrome sincronizam em segundo plano.',
     playlistDeleted: 'Playlist "{name}" removida ({count} faixas).',
     playlistDeleteFailed: 'Não foi possível excluir a playlist "{name}".',
+    pathsScanning:
+      'Procurando novos arquivos em segundo plano. A lista pode atualizar em breve.',
   },
   monitor: {
     title: 'Monitor de playlists',

--- a/frontend/src/model/api.js
+++ b/frontend/src/model/api.js
@@ -148,6 +148,22 @@ function listDownloads(forceRefresh = false) {
   })
 }
 
+function listDownloadsPage({
+  page = 1,
+  limit = 25,
+  q = '',
+  playlist = '',
+  refresh = false,
+} = {}) {
+  const params = { page, limit }
+  const query = String(q || '').trim()
+  const pl = String(playlist || '').trim()
+  if (query) params.q = query
+  if (pl) params.playlist = pl
+  if (refresh) params.refresh = true
+  return API.get('/list', { params })
+}
+
 function deleteDownload(file) {
   return API.delete('/delete', { params: { file } })
 }
@@ -230,6 +246,7 @@ export default {
   downloadSaveName,
   coverFileURL,
   listDownloads,
+  listDownloadsPage,
   deleteDownload,
   deleteDownloadsBatch,
   deleteLibraryPlaylist,

--- a/frontend/src/views/Downloads.vue
+++ b/frontend/src/views/Downloads.vue
@@ -28,7 +28,7 @@
             {{ t('library.deleteSelected', { count: selectedCount }) }}
           </button>
           <button
-            v-if="filteredFiles.length > 0"
+            v-if="totalItems > 0"
             class="btn btn-primary btn-sm h-11 px-5 rounded-full"
             @click="playAll"
             :title="t('library.play')"
@@ -75,9 +75,16 @@
         </button>
       </div>
 
+      <p
+        v-if="pathsScanning"
+        class="mb-3 text-xs text-base-content/50 text-center"
+      >
+        {{ t('library.pathsScanning') }}
+      </p>
+
       <!-- Playlist filter + bulk selection -->
       <div
-        v-if="files.length > 0"
+        v-if="totalItems > 0"
         class="mb-4 flex flex-wrap items-center gap-2"
       >
         <label class="text-xs text-base-content/50 shrink-0">
@@ -103,17 +110,15 @@
         </button>
         <span class="flex-1" />
         <button
-          v-if="filteredFiles.length > 0"
+          v-if="paginatedFiles.length > 0"
           type="button"
           class="btn btn-ghost btn-xs rounded-full"
-          @click="toggleSelectAllFiltered"
+          @click="toggleSelectAllPage"
         >
           {{
-            allFilteredSelected
+            allPageSelected
               ? t('library.clearSelection')
-              : t('library.selectAllFilteredCount', {
-                  count: filteredFiles.length,
-                })
+              : t('library.selectAllFiltered')
           }}
         </button>
       </div>
@@ -132,9 +137,27 @@
         <div v-for="n in 4" :key="n" class="skeleton h-16 rounded-2xl" />
       </div>
 
+      <!-- No search matches -->
+      <div
+        v-else-if="
+          !loading &&
+          totalItems === 0 &&
+          (libraryFilterQuery.trim() || playlistFilter)
+        "
+        class="surface rounded-2xl p-12 flex flex-col items-center text-center"
+      >
+        <Icon
+          icon="clarity:search-line"
+          class="h-12 w-12 text-base-content/20 mb-4"
+        />
+        <p class="text-base-content/50 text-sm">
+          {{ t('library.searchNoResults') }}
+        </p>
+      </div>
+
       <!-- Empty library -->
       <div
-        v-else-if="files.length === 0"
+        v-else-if="!loading && totalItems === 0"
         class="surface rounded-2xl p-12 flex flex-col items-center text-center"
       >
         <Icon
@@ -144,20 +167,6 @@
         <p class="text-base-content/50 text-sm">{{ t('library.empty') }}</p>
         <p class="text-base-content/40 text-xs mt-1">
           {{ t('library.emptyHint') }}
-        </p>
-      </div>
-
-      <!-- No search matches -->
-      <div
-        v-else-if="filteredFiles.length === 0"
-        class="surface rounded-2xl p-12 flex flex-col items-center text-center"
-      >
-        <Icon
-          icon="clarity:search-line"
-          class="h-12 w-12 text-base-content/20 mb-4"
-        />
-        <p class="text-base-content/50 text-sm">
-          {{ t('library.searchNoResults') }}
         </p>
       </div>
 
@@ -261,33 +270,33 @@
       </ul>
 
       <LibraryPagination
-        v-if="filteredFiles.length > 0"
+        v-if="totalItems > 0"
         :current-page="currentPage"
         :total-pages="totalPages"
-        :total-items="filteredFiles.length"
+        :total-items="totalItems"
         :page-size="pageSize"
-        @update:current-page="currentPage = $event"
+        @update:current-page="onPageChange"
         @update:page-size="onPageSizeChange"
       />
 
       <!-- Count footer -->
       <p
-        v-if="files.length > 0"
+        v-if="totalItems > 0"
         class="mt-4 text-xs text-base-content/40 text-center"
       >
-        <template v-if="libraryFilterQuery.trim()">
+        <template v-if="libraryFilterQuery.trim() || playlistFilter">
           {{
             t('library.filteredCount', {
-              shown: filteredFiles.length,
-              total: files.length,
+              shown: paginatedFiles.length,
+              total: totalItems,
             })
           }}
         </template>
         <template v-else>
           {{
-            files.length === 1
-              ? t('library.countOne', { count: files.length })
-              : t('library.countMany', { count: files.length })
+            totalItems === 1
+              ? t('library.countOne', { count: totalItems })
+              : t('library.countMany', { count: totalItems })
           }}
         </template>
       </p>
@@ -305,10 +314,7 @@ import Settings from '/src/components/Settings.vue'
 import LibraryPagination from '/src/components/LibraryPagination.vue'
 import API from '/src/model/api'
 import { useI18n } from '/src/i18n'
-import {
-  useLibraryFilter,
-  libraryEntryMatchesQuery,
-} from '/src/model/libraryFilter'
+import { useLibraryFilter } from '/src/model/libraryFilter'
 import {
   normalizeLibraryEntry,
   savePlayerViewPrefs,
@@ -324,6 +330,7 @@ const router = useRouter()
 const { libraryFilterQuery, clearLibraryFilter } = useLibraryFilter()
 
 const files = ref([])
+const totalItems = ref(0)
 const loading = ref(false)
 const error = ref('')
 const deleting = ref({})
@@ -334,56 +341,31 @@ const currentPage = ref(1)
 const pageSize = ref(readPageSize())
 const selectedFiles = ref(new Set())
 const playlistFilter = ref('')
+const playlistNames = ref([])
+const pathsScanning = ref(false)
+let filterDebounce = null
 
-const playlistNames = computed(() => {
-  const names = new Set()
-  for (const entry of files.value) {
-    for (const pl of entry.playlists || []) {
-      if (pl) names.add(pl)
-    }
-  }
-  return [...names].sort((a, b) => a.localeCompare(b))
-})
-
-const filteredFiles = computed(() => {
-  let list = files.value
-  const pl = String(playlistFilter.value || '').trim()
-  if (pl) {
-    list = list.filter((entry) => (entry.playlists || []).includes(pl))
-  }
-  const query = libraryFilterQuery.value
-  if (!String(query || '').trim()) return list
-  return list.filter((entry) => libraryEntryMatchesQuery(entry, query))
-})
+const paginatedFiles = computed(() => files.value)
 
 const selectedCount = computed(() => selectedFiles.value.size)
 
-const allFilteredSelected = computed(() => {
-  if (!filteredFiles.value.length) return false
-  return filteredFiles.value.every((e) => selectedFiles.value.has(e.file))
+const allPageSelected = computed(() => {
+  if (!paginatedFiles.value.length) return false
+  return paginatedFiles.value.every((e) => selectedFiles.value.has(e.file))
 })
 
 const totalPages = computed(() =>
-  Math.max(1, Math.ceil(filteredFiles.value.length / pageSize.value))
+  Math.max(1, Math.ceil(totalItems.value / pageSize.value))
 )
 
-const paginatedFiles = computed(() => {
-  const start = (currentPage.value - 1) * pageSize.value
-  return filteredFiles.value.slice(start, start + pageSize.value)
-})
-
-watch([filteredFiles, pageSize], () => {
-  if (currentPage.value > totalPages.value) {
-    currentPage.value = totalPages.value
-  }
-})
-
-watch(libraryFilterQuery, () => {
+watch([libraryFilterQuery, playlistFilter], () => {
   currentPage.value = 1
+  scheduleLoad()
 })
 
-watch(playlistFilter, () => {
+watch(pageSize, () => {
   currentPage.value = 1
+  loadPage()
 })
 
 function toggleSelect(file) {
@@ -393,17 +375,18 @@ function toggleSelect(file) {
   selectedFiles.value = next
 }
 
-function toggleSelectAllFiltered() {
-  if (allFilteredSelected.value) {
+function toggleSelectAllPage() {
+  if (allPageSelected.value) {
     selectedFiles.value = new Set()
     return
   }
-  selectedFiles.value = new Set(filteredFiles.value.map((entry) => entry.file))
+  selectedFiles.value = new Set(paginatedFiles.value.map((entry) => entry.file))
 }
 
 function removeFilesFromList(paths) {
   const gone = new Set(paths)
   files.value = files.value.filter((entry) => !gone.has(entry.file))
+  totalItems.value = Math.max(0, totalItems.value - gone.size)
   const next = new Set(selectedFiles.value)
   for (const p of gone) next.delete(p)
   selectedFiles.value = next
@@ -437,17 +420,73 @@ function markCoverFailed(file) {
   coverFailed.value = { ...coverFailed.value, [file]: true }
 }
 
-async function refresh() {
+function scheduleLoad() {
+  if (filterDebounce) clearTimeout(filterDebounce)
+  filterDebounce = setTimeout(() => {
+    filterDebounce = null
+    loadPage()
+  }, 300)
+}
+
+function onPageChange(page) {
+  currentPage.value = page
+  loadPage()
+}
+
+async function loadPage({ refresh = false } = {}) {
   loading.value = true
   error.value = ''
   try {
-    const res = await API.listDownloads(true)
-    files.value = (res.data || []).map(normalizeLibraryEntry)
+    const res = await API.listDownloadsPage({
+      page: currentPage.value,
+      limit: pageSize.value,
+      q: libraryFilterQuery.value,
+      playlist: playlistFilter.value,
+      refresh,
+    })
+    const data = res.data || {}
+    files.value = (data.items || []).map(normalizeLibraryEntry)
+    totalItems.value = Number(data.total) || 0
+    pathsScanning.value = Boolean(data.paths_scanning)
+    if (Array.isArray(data.playlist_names) && data.playlist_names.length) {
+      playlistNames.value = data.playlist_names
+    }
+    if (currentPage.value > totalPages.value) {
+      currentPage.value = totalPages.value
+      if (currentPage.value >= 1) {
+        await loadPage({ refresh: false })
+      }
+    }
   } catch {
     error.value = t('library.failedLoad')
   } finally {
     loading.value = false
   }
+}
+
+async function refresh() {
+  currentPage.value = 1
+  await loadPage({ refresh: true })
+}
+
+async function fetchAllFilteredEntries() {
+  const items = []
+  let page = 1
+  let total = 1
+  while (items.length < total) {
+    const res = await API.listDownloadsPage({
+      page,
+      limit: 200,
+      q: libraryFilterQuery.value,
+      playlist: playlistFilter.value,
+    })
+    const data = res.data || {}
+    items.push(...(data.items || []).map(normalizeLibraryEntry))
+    total = Number(data.total) || items.length
+    page += 1
+    if (page > 100) break
+  }
+  return items
 }
 
 async function onDelete(file) {
@@ -510,11 +549,9 @@ async function onDeletePlaylist() {
   try {
     const res = await API.deleteLibraryPlaylist(name)
     const count = res.data?.deleted_count ?? 0
-    files.value = files.value.filter(
-      (entry) => !(entry.playlists || []).includes(name)
-    )
     selectedFiles.value = new Set()
     playlistFilter.value = ''
+    await loadPage()
     if ((res.data?.failed_count || 0) > 0) {
       error.value = t('library.batchDeletePartial', {
         ok: count,
@@ -549,22 +586,24 @@ function persistPlayerViewForPlayback() {
   })
 }
 
-function playEntry(entry) {
-  const index = filteredFiles.value.findIndex((row) => row.file === entry.file)
+async function playEntry(entry) {
+  const tracks = await fetchAllFilteredEntries()
+  const index = tracks.findIndex((row) => row.file === entry.file)
   if (index < 0) return
   persistPlayerViewForPlayback()
-  player.setPlaylist(filteredFiles.value, { startIndex: index, autoplay: true })
+  player.setPlaylist(tracks, { startIndex: index, autoplay: true })
   router.push({ name: 'Player' })
 }
 
-function playAll() {
-  if (!filteredFiles.value.length) return
+async function playAll() {
+  const tracks = await fetchAllFilteredEntries()
+  if (!tracks.length) return
   persistPlayerViewForPlayback()
-  player.setPlaylist(filteredFiles.value, { startIndex: 0, autoplay: true })
+  player.setPlaylist(tracks, { startIndex: 0, autoplay: true })
   router.push({ name: 'Player' })
 }
 
-onMounted(refresh)
+onMounted(() => loadPage())
 
 onUnmounted(() => {
   clearLibraryFilter()

--- a/frontend/src/views/Downloads.vue
+++ b/frontend/src/views/Downloads.vue
@@ -83,10 +83,7 @@
       </p>
 
       <!-- Playlist filter + bulk selection -->
-      <div
-        v-if="totalItems > 0"
-        class="mb-4 flex flex-wrap items-center gap-2"
-      >
+      <div v-if="totalItems > 0" class="mb-4 flex flex-wrap items-center gap-2">
         <label class="text-xs text-base-content/50 shrink-0">
           {{ t('library.filterByPlaylist') }}
         </label>

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncIterator
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, Response
 from fastapi.staticfiles import StaticFiles
@@ -42,11 +42,21 @@ from downtify.library_catalog import (
     LibraryContext,
     library_context_from_state,
     list_library_entries,
+    list_library_entries_page,
     resolve_library_file,
+    scan_library_paths,
 )
 from downtify.library_delete import delete_library_file
 from downtify.library_metadata_cache import LibraryMetadataCache
-from downtify.library_paths_cache import invalidate_library_paths_cache
+from downtify.library_paths_cache import (
+    request_paths_rescan,
+    set_paths_rescan_callback,
+)
+from downtify.library_paths_scanner import (
+    library_paths_scan_loop,
+    library_paths_scan_running,
+    schedule_library_paths_rescan,
+)
 from downtify.library_reconcile import refresh_playlists_after_moves
 from downtify.monitor import PlaylistMonitorDB, monitor_loop
 from downtify.navidrome_index import NavidromeIndex
@@ -150,6 +160,17 @@ class LibraryListEntry(BaseModel):
     playlists: list[str] = Field(default_factory=list)
 
 
+class LibraryListPage(BaseModel):
+    """Paginated ``GET /list`` response."""
+
+    items: list[LibraryListEntry]
+    total: int
+    page: int
+    limit: int
+    paths_scanning: bool = False
+    playlist_names: list[str] = Field(default_factory=list)
+
+
 async def _application_startup() -> None:
     loop = asyncio.get_running_loop()
     api.state.loop = loop
@@ -202,6 +223,29 @@ async def _application_startup() -> None:
                 )
     except Exception:
         logger.exception('Playlist batch sync from library failed')
+
+    def _library_ctx() -> LibraryContext:
+        return library_context_from_state(
+            DOWNLOAD_DIR,
+            api.state.settings,
+            api.state.track_index,
+            metadata_cache=api.state.metadata_cache,
+            playlist_catalog=api.state.playlist_catalog,
+        )
+
+    async def _rescan_library_paths() -> None:
+        await schedule_library_paths_rescan(_library_ctx(), scan_library_paths)
+
+    def _schedule_library_paths_rescan() -> None:
+        asyncio.create_task(_rescan_library_paths())
+
+    api.state.schedule_library_paths_rescan = _schedule_library_paths_rescan
+    set_paths_rescan_callback(_schedule_library_paths_rescan)
+    _schedule_library_paths_rescan()
+    asyncio.create_task(
+        library_paths_scan_loop(_library_ctx, scan_library_paths)
+    )
+
     asyncio.create_task(
         monitor_loop(
             db=api.state.monitor_db,
@@ -285,12 +329,57 @@ def build_app() -> FastAPI:
             playlist_catalog=api.state.playlist_catalog,
         )
 
-    @app.get('/list', response_model=list[LibraryListEntry])
-    def list_downloads(refresh: bool = False) -> list[LibraryListEntry]:
+    def _playlist_names_for_library() -> list[str]:
+        catalog = api.state.playlist_catalog
+        if catalog is None:
+            return []
+        return catalog.list_playlist_names()
+
+    @app.get('/list')
+    async def list_downloads(
+        refresh: bool = False,
+        page: int | None = Query(default=None, ge=1),
+        limit: int = Query(default=25, ge=1, le=200),
+        q: str = Query(default=''),
+        playlist: str = Query(default=''),
+    ) -> list[LibraryListEntry] | LibraryListPage:
+        ctx = _library_ctx()
         if refresh:
-            invalidate_library_paths_cache()
-        rows = list_library_entries(_library_ctx())
-        return [LibraryListEntry.model_validate(row) for row in rows]
+            request_paths_rescan(ctx)
+            schedule = getattr(
+                api.state, 'schedule_library_paths_rescan', None
+            )
+            if callable(schedule):
+                schedule()
+
+        if page is not None:
+
+            def _page() -> LibraryListPage:
+                rows, total = list_library_entries_page(
+                    ctx,
+                    page=page,
+                    limit=limit,
+                    query=q,
+                    playlist=playlist,
+                )
+                return LibraryListPage(
+                    items=[
+                        LibraryListEntry.model_validate(row) for row in rows
+                    ],
+                    total=total,
+                    page=page,
+                    limit=limit,
+                    paths_scanning=library_paths_scan_running(ctx),
+                    playlist_names=_playlist_names_for_library(),
+                )
+
+            return await asyncio.to_thread(_page)
+
+        def _all() -> list[LibraryListEntry]:
+            rows = list_library_entries(ctx)
+            return [LibraryListEntry.model_validate(row) for row in rows]
+
+        return await asyncio.to_thread(_all)
 
     @app.get('/media/{file_path:path}')
     def serve_media(file_path: str) -> FileResponse:
@@ -339,15 +428,20 @@ def build_app() -> FastAPI:
 
     @app.delete('/delete')
     async def delete_download(file: str) -> dict:
-        result = delete_library_file(
-            file,
-            _library_ctx(),
-            cover_cache=api.state.cover_cache,
-            metadata_cache=api.state.metadata_cache,
-            playlist_catalog=api.state.playlist_catalog,
-            track_index=api.state.track_index,
-            navidrome_index=api.state.navidrome_index,
-        )
+        ctx = _library_ctx()
+
+        def _run() -> dict:
+            return delete_library_file(
+                file,
+                ctx,
+                cover_cache=api.state.cover_cache,
+                metadata_cache=api.state.metadata_cache,
+                playlist_catalog=api.state.playlist_catalog,
+                track_index=api.state.track_index,
+                navidrome_index=api.state.navidrome_index,
+            )
+
+        result = await asyncio.to_thread(_run)
         if not result.get('deleted'):
             return {
                 'deleted': False,
@@ -363,39 +457,44 @@ def build_app() -> FastAPI:
         }
 
     @app.get('/cover')
-    def get_cover(file: str):
-        full = resolve_library_file(file, _library_ctx())
-        if full is None:
-            raise HTTPException(status_code=404, detail='File not found')
+    async def get_cover(file: str):
+        ctx = _library_ctx()
 
-        data: bytes | None = None
-        mime: str | None = None
-        if api.state.settings.get('cache_cover_art'):
-            cache = api.state.cover_cache
-            if cache is not None:
-                hit = cache.lookup(file, full)
-                if hit is not None:
-                    data, mime = hit
-        if data is None:
-            data, mime = extract_cover_art(full)
-            if data is None:
-                return Response(
-                    content=_TRANSPARENT_GIF,
-                    media_type='image/gif',
-                    headers={'Cache-Control': 'public, max-age=3600'},
-                )
+        def _load() -> Response:
+            full = resolve_library_file(file, ctx)
+            if full is None:
+                raise HTTPException(status_code=404, detail='File not found')
+
+            data: bytes | None = None
+            mime: str | None = None
             if api.state.settings.get('cache_cover_art'):
                 cache = api.state.cover_cache
                 if cache is not None:
-                    cache.store(file, full, data, mime or 'image/jpeg')
-        return Response(
-            content=data,
-            media_type=mime or 'image/jpeg',
-            headers={
-                'Cache-Control': 'public, max-age=86400',
-                'ETag': f'"{int(full.stat().st_mtime)}"',
-            },
-        )
+                    hit = cache.lookup(file, full)
+                    if hit is not None:
+                        data, mime = hit
+            if data is None:
+                data, mime = extract_cover_art(full)
+                if data is None:
+                    return Response(
+                        content=_TRANSPARENT_GIF,
+                        media_type='image/gif',
+                        headers={'Cache-Control': 'public, max-age=3600'},
+                    )
+                if api.state.settings.get('cache_cover_art'):
+                    cache = api.state.cover_cache
+                    if cache is not None:
+                        cache.store(file, full, data, mime or 'image/jpeg')
+            return Response(
+                content=data,
+                media_type=mime or 'image/jpeg',
+                headers={
+                    'Cache-Control': 'public, max-age=86400',
+                    'ETag': f'"{int(full.stat().st_mtime)}"',
+                },
+            )
+
+        return await asyncio.to_thread(_load)
 
     app.mount(
         '/downloads',

--- a/tests/test_library_catalog.py
+++ b/tests/test_library_catalog.py
@@ -7,11 +7,14 @@ from mutagen.id3 import ID3, TIT2, TPE1
 from downtify.library_catalog import (
     LibraryContext,
     list_library_entries,
+    list_library_entries_page,
     list_library_paths,
     resolve_library_file,
+    scan_library_paths,
 )
 from downtify.library_metadata_cache import LibraryMetadataCache
 from downtify.library_paths import library_stored_path
+from downtify.library_paths_cache import set_cached_paths
 
 
 def test_list_library_includes_slskd_tree(tmp_path):
@@ -25,6 +28,7 @@ def test_list_library_includes_slskd_tree(tmp_path):
     slskd_track.write_bytes(b's')
 
     ctx = LibraryContext(download_dir=download_dir, slskd_dir=slskd_dir)
+    set_cached_paths(ctx, scan_library_paths(ctx))
     paths = list_library_paths(ctx)
 
     assert 'YouTube - Song.mp3' in paths
@@ -64,11 +68,26 @@ def test_list_library_entries_reads_embedded_tags(tmp_path):
     ctx = LibraryContext(
         download_dir=download_dir, slskd_dir=slskd_dir, metadata_cache=cache
     )
+    set_cached_paths(ctx, scan_library_paths(ctx))
     entries = list_library_entries(ctx)
     assert len(entries) == 1
     assert entries[0]['title'] == 'Real Title'
     assert entries[0]['artist'] == 'Real Artist'
     assert entries[0]['file'].startswith('slskd/')
+
+
+def test_list_library_entries_page_returns_slice(tmp_path):
+    download_dir = tmp_path / 'downloads'
+    download_dir.mkdir()
+    for index in range(5):
+        (download_dir / f'Track {index}.mp3').write_bytes(b'x')
+
+    cache = LibraryMetadataCache(tmp_path / 'library.db')
+    ctx = LibraryContext(download_dir=download_dir, metadata_cache=cache)
+    set_cached_paths(ctx, scan_library_paths(ctx))
+    rows, total = list_library_entries_page(ctx, page=2, limit=2)
+    assert total == 5
+    assert len(rows) == 2
 
 
 def test_resolve_library_file_legacy_dotdot_slskd_path(tmp_path):

--- a/tests/test_library_metadata_cache.py
+++ b/tests/test_library_metadata_cache.py
@@ -10,8 +10,8 @@ from mutagen.id3 import ID3, TIT2, TPE1
 
 from downtify.library_catalog import (
     LibraryContext,
-    scan_library_paths,
     list_library_entries,
+    scan_library_paths,
 )
 from downtify.library_metadata_cache import LibraryMetadataCache
 from downtify.library_paths_cache import set_cached_paths

--- a/tests/test_library_metadata_cache.py
+++ b/tests/test_library_metadata_cache.py
@@ -8,8 +8,13 @@ from unittest.mock import patch
 
 from mutagen.id3 import ID3, TIT2, TPE1
 
-from downtify.library_catalog import LibraryContext, list_library_entries
+from downtify.library_catalog import (
+    LibraryContext,
+    scan_library_paths,
+    list_library_entries,
+)
 from downtify.library_metadata_cache import LibraryMetadataCache
+from downtify.library_paths_cache import set_cached_paths
 from downtify.sqlite_utils import connect_sqlite
 
 
@@ -31,6 +36,7 @@ def test_cache_hit_skips_mutagen(tmp_path: Path) -> None:
     cache.refresh('Artist - Song.mp3', track)
 
     ctx = LibraryContext(download_dir=download_dir, metadata_cache=cache)
+    set_cached_paths(ctx, scan_library_paths(ctx))
     with patch('downtify.library_metadata.read_audio_metadata') as read_meta:
         entries = list_library_entries(ctx)
         read_meta.assert_not_called()

--- a/tests/test_playlist_catalog_lookup.py
+++ b/tests/test_playlist_catalog_lookup.py
@@ -7,11 +7,11 @@ from pathlib import Path
 
 from downtify.library_catalog import (
     LibraryContext,
-    scan_library_paths,
     list_library_entries,
+    scan_library_paths,
 )
-from downtify.library_paths_cache import set_cached_paths
 from downtify.library_metadata_cache import LibraryMetadataCache
+from downtify.library_paths_cache import set_cached_paths
 from downtify.library_reconcile import prune_stale_and_backfill
 from downtify.playlist_catalog import PlaylistCatalog
 

--- a/tests/test_playlist_catalog_lookup.py
+++ b/tests/test_playlist_catalog_lookup.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-from downtify.library_catalog import LibraryContext, list_library_entries
+from downtify.library_catalog import (
+    LibraryContext,
+    scan_library_paths,
+    list_library_entries,
+)
+from downtify.library_paths_cache import set_cached_paths
 from downtify.library_metadata_cache import LibraryMetadataCache
 from downtify.library_reconcile import prune_stale_and_backfill
 from downtify.playlist_catalog import PlaylistCatalog
@@ -31,6 +36,7 @@ def test_playlists_on_list_entries(tmp_path: Path) -> None:
         metadata_cache=cache,
         playlist_catalog=catalog,
     )
+    set_cached_paths(ctx, scan_library_paths(ctx))
     entries = list_library_entries(ctx)
     assert len(entries) == 1
     assert entries[0]['playlists'] == ['Road Mix']


### PR DESCRIPTION
## Summary
- Offload blocking endpoints (`/list`, `/cover`, `/delete`, search, Spotify URL resolve) to `asyncio.to_thread` so one slow request no longer freezes search, playlists, and monitor.
- Add background library path scanning and server-side paginated `GET /list?page=&limit=&q=&playlist=`; Library UI loads one page at a time instead of the full catalog.
- Cache playlist batch summaries for 30s and invalidate when library paths change.

## Test plan
- [ ] Restart backend and open Library — first page loads quickly; optional “scanning in background” message may appear briefly
- [ ] Search for a track/album while Library is open — search should stay responsive
- [ ] Open Monitor and Search playlist batches — lists load without long freezes
- [ ] Player and “Play playlist” from Search still work (full `/list` without `page` unchanged)
- [ ] `npm --prefix frontend run build` before deploy (frontend source changed; `frontend/dist` not committed)


Made with [Cursor](https://cursor.com)