### PR TITLE
Fix queue bloat and library path rescan warnings

### DIFF
--- a/downtify/api.py
+++ b/downtify/api.py
@@ -891,6 +891,36 @@ def _register_job(song: dict[str, Any], status: str = 'queued') -> str:
     return song_id
 
 
+def _clear_completed_jobs() -> int:
+    """Remove finished jobs from the in-memory queue."""
+
+    removed = [
+        song_id
+        for song_id, job in list(state.download_jobs.items())
+        if job.get('status') == 'done'
+    ]
+    for song_id in removed:
+        del state.download_jobs[song_id]
+    return len(removed)
+
+
+async def _prune_queue_after_batch() -> int:
+    """Drop completed jobs once a download batch finishes."""
+
+    cleared = _clear_completed_jobs()
+    if cleared:
+        logger.debug(
+            'Cleared {} completed queue job(s) after batch finished',
+            cleared,
+        )
+    invalidate_playlist_batch_reports_cache()
+    await state.connections.broadcast({
+        'status': 'playlist_batches_changed',
+        'queue_pruned': cleared,
+    })
+    return cleared
+
+
 async def _run_download(  # noqa: PLR0914
     song: dict[str, Any],
     song_id: str,
@@ -1288,6 +1318,25 @@ def _rebuild_playlist_catalog_from_library(
 
 
 async def _process_batch(
+    songs: list[dict[str, Any]],
+    job_ids: list[str],
+    playlist_url: str,
+    generate_m3u: bool,
+    batch_id: Optional[int] = None,
+) -> None:
+    try:
+        await _run_process_batch(
+            songs,
+            job_ids,
+            playlist_url,
+            generate_m3u,
+            batch_id=batch_id,
+        )
+    finally:
+        await _prune_queue_after_batch()
+
+
+async def _run_process_batch(
     songs: list[dict[str, Any]],
     job_ids: list[str],
     playlist_url: str,
@@ -2093,6 +2142,13 @@ async def _submit_playlist_batch(
     generate_m3u: bool,
     batch_id: Optional[int] = None,
 ) -> dict[str, Any]:
+    cleared = _clear_completed_jobs()
+    if cleared:
+        logger.debug(
+            'Cleared {} completed queue job(s) before playlist batch',
+            cleared,
+        )
+
     valid_songs: list[dict[str, Any]] = []
     job_ids: list[str] = []
     for song in songs:
@@ -2458,14 +2514,7 @@ def clear_queue() -> dict:
 @router.delete('/api/queue/completed')
 def clear_completed_queue() -> dict:
     """Remove finished jobs so a new playlist queue is easier to read."""
-    removed = [
-        song_id
-        for song_id, job in list(state.download_jobs.items())
-        if job.get('status') == 'done'
-    ]
-    for song_id in removed:
-        del state.download_jobs[song_id]
-    return {'removed': len(removed)}
+    return {'removed': _clear_completed_jobs()}
 
 
 @router.delete('/api/queue/item')

--- a/downtify/library_paths_cache.py
+++ b/downtify/library_paths_cache.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING
 
+from loguru import logger
+
 if TYPE_CHECKING:
     from .library_catalog import LibraryContext
 
@@ -90,9 +92,9 @@ def invalidate_library_paths_cache() -> None:
         try:
             _rescan_callback()
         except Exception:
-            pass
+            logger.exception('Library paths rescan callback failed')
     for listener in _change_listeners:
         try:
             listener()
         except Exception:
-            pass
+            logger.exception('Library paths change listener failed')

--- a/frontend/src/components/DownloadList.vue
+++ b/frontend/src/components/DownloadList.vue
@@ -321,7 +321,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, reactive, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, reactive, onMounted } from 'vue'
 import { Icon } from '@iconify/vue'
 import API from '../model/api'
 import {
@@ -464,20 +464,8 @@ watch(pendingCount, (pending, prev) => {
   }
 })
 
-let queueRefreshTimer = null
-
 onMounted(() => {
   syncQueueFromServer().catch(() => {})
-  queueRefreshTimer = setInterval(() => {
-    syncQueueFromServer().catch(() => {})
-  }, 2000)
-})
-
-onUnmounted(() => {
-  if (queueRefreshTimer) {
-    clearInterval(queueRefreshTimer)
-    queueRefreshTimer = null
-  }
 })
 
 async function onClearAll() {

--- a/frontend/src/components/IncompletePlaylists.vue
+++ b/frontend/src/components/IncompletePlaylists.vue
@@ -303,7 +303,11 @@ import { ref, reactive, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { Icon } from '@iconify/vue'
 import API from '../model/api'
-import { syncQueueFromServer } from '../model/download'
+import {
+  onPlaylistBatchesChanged,
+  pruneCompletedQueue,
+  syncQueueFromServer,
+} from '../model/download'
 import {
   normalizeLibraryEntry,
   savePlayerViewPrefs,
@@ -334,6 +338,7 @@ let progressRefreshTimer = null
 let verifyBusy = false
 let progressRefreshBusy = false
 const progressWatchIds = new Set()
+let stopPlaylistBatchListener = null
 
 const VERIFY_STALE_MS = 5 * 60 * 1000
 const VERIFY_TICK_MS = 1200
@@ -770,6 +775,7 @@ async function onDownloadMissing(pl) {
   downloadingMissing.value = id
   trackProgressPlaylist(id)
   try {
+    await pruneCompletedQueue()
     await API.downloadMissingPlaylistTracks({
       spotify_playlist_id: id,
       playlist_url: pl.playlist_url,
@@ -841,6 +847,9 @@ function onDownloadTrack(pl, track) {
 }
 
 onMounted(() => {
+  stopPlaylistBatchListener = onPlaylistBatchesChanged(() => {
+    refreshPlaylists().catch(() => {})
+  })
   refreshPlaylists()
     .then(() => {
       tickVerify().catch(() => {})
@@ -858,6 +867,10 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  if (stopPlaylistBatchListener) {
+    stopPlaylistBatchListener()
+    stopPlaylistBatchListener = null
+  }
   if (refreshTimer) {
     clearInterval(refreshTimer)
     refreshTimer = null

--- a/frontend/src/model/download.js
+++ b/frontend/src/model/download.js
@@ -166,6 +166,34 @@ export function useProgressTracker() {
 
 const progressTracker = useProgressTracker()
 
+const playlistBatchListeners = new Set()
+
+export function onPlaylistBatchesChanged(listener) {
+  playlistBatchListeners.add(listener)
+  return () => playlistBatchListeners.delete(listener)
+}
+
+function notifyPlaylistBatchesChanged() {
+  for (const listener of playlistBatchListeners) {
+    try {
+      listener()
+    } catch (e) {
+      console.log('playlist batch listener failed:', e)
+    }
+  }
+}
+
+function applyQueuePruned(removed) {
+  if (!removed) return
+  downloadQueue.value = downloadQueue.value.filter(
+    (item) => !item.isDownloaded()
+  )
+  touchQueue()
+  if (!queueHasActiveItems()) {
+    stopQueuePoll()
+  }
+}
+
 let queuePollTimer = null
 
 function queueHasActiveItems() {
@@ -192,12 +220,27 @@ function ensureQueuePoll() {
   }, 3000)
 }
 
+export async function pruneCompletedQueue() {
+  downloadQueue.value = downloadQueue.value.filter(
+    (item) => !item.isDownloaded()
+  )
+  touchQueue()
+  try {
+    await API.clearCompletedQueue()
+  } catch (e) {
+    console.log('Failed to clear completed queue on server:', e)
+  }
+}
+
 export async function syncQueueFromServer() {
   const res = await API.getQueue()
   const jobs = res.data || []
+  const serverKeys = new Set()
   for (const job of jobs) {
     const song = job.song
     if (!song) continue
+    const key = jobSongKey(song)
+    if (key) serverKeys.add(key)
     let item = progressTracker.getBySong(song)
     if (!item) {
       item = new DownloadItem(song)
@@ -205,6 +248,11 @@ export async function syncQueueFromServer() {
     }
     applyServerJob(item, job)
   }
+  downloadQueue.value = downloadQueue.value.filter((item) => {
+    if (!item.isDownloaded()) return true
+    const key = jobSongKey(item.song)
+    return key && serverKeys.has(key)
+  })
   touchQueue()
   if (queueHasActiveItems()) {
     ensureQueuePoll()
@@ -215,6 +263,18 @@ export async function syncQueueFromServer() {
 
 API.ws_onmessage((event) => {
   let data = JSON.parse(event.data)
+  if (data.status === 'playlist_batches_changed') {
+    applyQueuePruned(data.queue_pruned || data.removed || 0)
+    notifyPlaylistBatchesChanged()
+    return
+  }
+  if (data.status === 'queue_pruned') {
+    applyQueuePruned(data.removed || 0)
+    return
+  }
+  if (!data.song) {
+    return
+  }
   let item = progressTracker.getBySong(data.song)
   if (!item) {
     progressTracker.appendSong(data.song)
@@ -247,7 +307,6 @@ API.ws_onmessage((event) => {
     item.wsUpdate(data)
   }
   ensureQueuePoll()
-  syncQueueFromServer().catch(() => {})
 })
 API.ws_onerror((event) => {
   console.log('websocket error:', event)
@@ -267,15 +326,7 @@ export function useDownloadManager() {
   const loading = ref(false)
   const settingsManager = useSettingsManager()
   async function pruneCompletedForNewPlaylist() {
-    downloadQueue.value = downloadQueue.value.filter(
-      (item) => !item.isDownloaded()
-    )
-    touchQueue()
-    try {
-      await API.clearCompletedQueue()
-    } catch (e) {
-      console.log('Failed to clear completed queue on server:', e)
-    }
+    await pruneCompletedQueue()
   }
 
   function _queueSongForBatch(song) {

--- a/frontend/src/views/Monitor.vue
+++ b/frontend/src/views/Monitor.vue
@@ -198,12 +198,16 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { Icon } from '@iconify/vue'
 import Navbar from '/src/components/Navbar.vue'
 import Settings from '/src/components/Settings.vue'
 import API from '/src/model/api.js'
 import monitorAPI from '/src/model/monitor.js'
+import {
+  onPlaylistBatchesChanged,
+  pruneCompletedQueue,
+} from '/src/model/download.js'
 import { useI18n } from '/src/i18n'
 
 const { t } = useI18n()
@@ -402,6 +406,7 @@ async function onDownloadMissing(pl) {
   const sid = pl.spotify_playlist_id
   downloading.value = { ...downloading.value, [sid]: true }
   try {
+    await pruneCompletedQueue()
     await API.downloadMissingPlaylistTracks({
       spotify_playlist_id: sid,
       playlist_url: pl.playlist_url,
@@ -441,5 +446,19 @@ function timeAgo(isoString) {
   }
 }
 
-onMounted(load)
+let stopPlaylistBatchListener = null
+
+onMounted(() => {
+  stopPlaylistBatchListener = onPlaylistBatchesChanged(() => {
+    load().catch(() => {})
+  })
+  load()
+})
+
+onUnmounted(() => {
+  if (stopPlaylistBatchListener) {
+    stopPlaylistBatchListener()
+    stopPlaylistBatchListener = null
+  }
+})
 </script>

--- a/main.py
+++ b/main.py
@@ -233,11 +233,16 @@ async def _application_startup() -> None:
             playlist_catalog=api.state.playlist_catalog,
         )
 
+    loop = asyncio.get_running_loop()
+
     async def _rescan_library_paths() -> None:
         await schedule_library_paths_rescan(_library_ctx(), scan_library_paths)
 
     def _schedule_library_paths_rescan() -> None:
-        asyncio.create_task(_rescan_library_paths())
+        def _start() -> None:
+            asyncio.create_task(_rescan_library_paths())
+
+        loop.call_soon_threadsafe(_start)
 
     api.state.schedule_library_paths_rescan = _schedule_library_paths_rescan
     set_paths_rescan_callback(_schedule_library_paths_rescan)

--- a/tests/test_api_queue.py
+++ b/tests/test_api_queue.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+from unittest.mock import AsyncMock
+
 from downtify import api
 
 
@@ -24,5 +27,67 @@ def test_clear_completed_queue_removes_only_done_jobs():
         assert done_id not in api.state.download_jobs
         assert err_id in api.state.download_jobs
         assert q_id in api.state.download_jobs
+    finally:
+        api.state.download_jobs.clear()
+
+
+def test_submit_playlist_batch_clears_completed_jobs():
+    api.state.download_jobs.clear()
+    try:
+        api._register_job({'song_id': 'done-1', 'name': 'Old'}, status='done')
+        api._register_job(
+            {'song_id': 'q-1', 'name': 'Active'}, status='queued'
+        )
+
+        asyncio.run(
+            api._submit_playlist_batch(
+                [{'song_id': 'new-1', 'name': 'Fresh', 'url': 'x'}],
+                'https://open.spotify.com/playlist/test',
+                generate_m3u=False,
+            )
+        )
+
+        assert 'done-1' not in api.state.download_jobs
+        assert 'q-1' in api.state.download_jobs
+        assert 'new-1' in api.state.download_jobs
+    finally:
+        api.state.download_jobs.clear()
+
+
+def test_prune_queue_after_batch_clears_done_and_broadcasts():
+    api.state.download_jobs.clear()
+    try:
+        api._register_job({'song_id': 'done-1', 'name': 'A'}, status='done')
+        api._register_job(
+            {'song_id': 'q-1', 'name': 'B'}, status='queued'
+        )
+        api.state.connections.broadcast = AsyncMock()
+
+        removed = asyncio.run(api._prune_queue_after_batch())
+
+        assert removed == 1
+        assert 'done-1' not in api.state.download_jobs
+        assert 'q-1' in api.state.download_jobs
+        api.state.connections.broadcast.assert_awaited_once_with(
+            {'status': 'playlist_batches_changed', 'queue_pruned': 1}
+        )
+    finally:
+        api.state.download_jobs.clear()
+
+
+def test_prune_queue_after_batch_broadcasts_when_nothing_to_clear():
+    api.state.download_jobs.clear()
+    try:
+        api._register_job(
+            {'song_id': 'q-1', 'name': 'B'}, status='queued'
+        )
+        api.state.connections.broadcast = AsyncMock()
+
+        removed = asyncio.run(api._prune_queue_after_batch())
+
+        assert removed == 0
+        api.state.connections.broadcast.assert_awaited_once_with(
+            {'status': 'playlist_batches_changed', 'queue_pruned': 0}
+        )
     finally:
         api.state.download_jobs.clear()

--- a/tests/test_library_paths_cache.py
+++ b/tests/test_library_paths_cache.py
@@ -1,0 +1,42 @@
+"""Tests for ``downtify.library_paths_cache``."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+from downtify.library_paths_cache import (
+    invalidate_library_paths_cache,
+    set_paths_rescan_callback,
+)
+
+
+def test_invalidate_rescan_callback_safe_from_worker_thread() -> None:
+    loop = asyncio.new_event_loop()
+    started: list[str] = []
+    done = threading.Event()
+
+    async def _rescan() -> None:
+        started.append('ok')
+        done.set()
+
+    def _schedule() -> None:
+        loop.call_soon_threadsafe(
+            lambda: asyncio.create_task(_rescan())
+        )
+
+    set_paths_rescan_callback(_schedule)
+    try:
+        thread = threading.Thread(target=invalidate_library_paths_cache)
+        thread.start()
+        thread.join()
+
+        async def _wait_done() -> None:
+            while not done.is_set():
+                await asyncio.sleep(0.01)
+
+        loop.run_until_complete(asyncio.wait_for(_wait_done(), timeout=1.0))
+        assert started == ['ok']
+    finally:
+        set_paths_rescan_callback(None)
+        loop.close()


### PR DESCRIPTION
## Summary
- Auto-prune completed download-queue jobs when playlist batches start and finish, and expose `pruneCompletedQueue()` for recheck/download-missing flows so large playlists stay responsive.
- Drop redundant full-queue sync on every WebSocket tick and remove the duplicate 2s poll on the queue page; rely on WS updates with a 3s fallback poll while downloads are active.
- Invalidate playlist-batch reports when a batch finishes and push `playlist_batches_changed` over WebSocket so incomplete playlists and monitor views refresh immediately.
- Schedule library path rescans on the main event loop via `call_soon_threadsafe`, fixing repeated `coroutine '_rescan_library_paths' was never awaited` warnings after downloads.

## Test plan
- [x] `uv run pytest tests/test_api_queue.py tests/test_library_paths_cache.py -v`
- [ ] Queue a large playlist, confirm completed rows clear after batch finish
- [ ] Confirm incomplete-playlist counts update without waiting for the 30s cache TTL
- [ ] Confirm Docker logs no longer show the library path rescan RuntimeWarning after downloads


Made with [Cursor](https://cursor.com)