### PR TITLE
fix(ci): prettify Settings.vue and fix prettier job permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,8 @@ jobs:
 
   prettier:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
@@ -73,3 +75,4 @@ jobs:
         uses: creyD/prettier_action@v4.6
         with:
           prettier_options: --write frontend/src/.
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/frontend/src/components/Settings.vue
+++ b/frontend/src/components/Settings.vue
@@ -176,8 +176,7 @@
               </ul>
               <pre
                 class="text-[10px] leading-relaxed text-base-content/60 whitespace-pre-wrap font-mono bg-base-300/30 rounded-lg px-2 py-1.5"
-                >{{ t('settings.slskdSourceDirExample') }}</pre
-              >
+                >{{ t('settings.slskdSourceDirExample') }}</pre>
             </div>
             <label class="text-[11px] text-base-content/50">
               {{ t('settings.slskdSourceDirLabel') }}


### PR DESCRIPTION
## Summary
- Format `Settings.vue` (prettier was failing on main after Dependabot merges)
- Grant `contents: write` to the prettier CI job so auto-format pushes work

## Context
Merges #39, #45, #46 succeeded but the **Test** workflow failed on the `prettier` job:
- `Settings.vue` needed formatting
- `github-actions[bot]` got 403 when trying to push the auto-format commit

Tests and frontend tests passed.

## Test plan
- [x] `npx prettier --check src/components/Settings.vue`
- CI on this PR

Made with [Cursor](https://cursor.com)