### PR TITLE
fix(library): hide Spotify ID playlist aliases and unstuck filter UI

### DIFF
--- a/downtify/api.py
+++ b/downtify/api.py
@@ -2702,6 +2702,18 @@ async def download_batch_endpoint(request: Request) -> dict[str, Any]:
         spotify_playlist_id = parsed[1]
         playlist_name = str(songs[0].get('album_name') or '').strip()
         if not playlist_name:
+            try:
+                meta_name, _tracks = await asyncio.to_thread(
+                    spotify.playlist_info_and_tracks,
+                    spotify_playlist_id,
+                )
+                playlist_name = str(meta_name or '').strip()
+            except Exception:
+                logger.opt(exception=True).warning(
+                    'Batch download: could not resolve playlist name for {}',
+                    spotify_playlist_id,
+                )
+        if not playlist_name:
             playlist_name = spotify_playlist_id
         batch_id = await asyncio.to_thread(
             state.playlist_batch_store.start_batch,

--- a/downtify/library_catalog.py
+++ b/downtify/library_catalog.py
@@ -12,7 +12,7 @@ from .library_metadata_cache import LibraryMetadataCache
 from .library_paths import library_stored_path, locate_library_file
 from .library_paths_cache import get_cached_paths
 from .playlist_catalog import PlaylistCatalog
-from .track_index import TrackIndex
+from .track_index import TrackIndex, is_spotify_id
 
 AUDIO_EXTENSIONS = frozenset({
     '.mp3',
@@ -194,15 +194,36 @@ def _library_path_pairs(ctx: LibraryContext) -> list[tuple[str, Path]]:
     return pairs
 
 
+def _resolve_playlist_filter_name(
+    catalog: PlaylistCatalog, playlist: str
+) -> str:
+    """Map a UI filter value to the catalog name that owns tracks."""
+
+    pl_name = str(playlist or '').strip()
+    if not pl_name:
+        return ''
+    if catalog.list_tracks(pl_name):
+        return pl_name
+    sid = catalog.spotify_id_for_playlist(pl_name) or (
+        pl_name if is_spotify_id(pl_name) else ''
+    )
+    if sid:
+        for candidate in catalog._names_for_spotify_id(sid):
+            if catalog.list_tracks(candidate):
+                return candidate
+    return pl_name
+
+
 def _paths_for_playlist(
     ctx: LibraryContext, playlist_name: str
 ) -> Optional[set[str]]:
     pl_name = str(playlist_name or '').strip()
     if not pl_name or ctx.playlist_catalog is None:
         return None
+    resolved = _resolve_playlist_filter_name(ctx.playlist_catalog, pl_name)
     names = {
         str(row.get('filename') or '').strip().replace('\\', '/')
-        for row in ctx.playlist_catalog.list_tracks(pl_name)
+        for row in ctx.playlist_catalog.list_tracks(resolved)
     }
     names.discard('')
     return names

--- a/downtify/playlist_catalog.py
+++ b/downtify/playlist_catalog.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 from .library_cache_keys import file_content_key
 from .library_paths import locate_library_file
 from .sqlite_utils import connect_sqlite
-from .track_index import normalize_spotify_track_id
+from .track_index import is_spotify_id, normalize_spotify_track_id
 
 
 def _now_iso() -> str:
@@ -251,12 +251,36 @@ class PlaylistCatalog:
             linked += 1
         return linked
 
+    def _names_for_spotify_id(self, spotify_id: str) -> list[str]:
+        sid = str(spotify_id or '').strip()
+        if not sid:
+            return []
+        with self._connect() as conn:
+            rows = conn.execute(
+                'SELECT name FROM playlists WHERE spotify_id = ? ORDER BY name',
+                (sid,),
+            ).fetchall()
+        return [str(row['name']) for row in rows if row['name']]
+
     def list_playlist_names(self) -> list[str]:
         with self._connect() as conn:
             rows = conn.execute(
-                'SELECT name FROM playlists ORDER BY name'
+                'SELECT name, spotify_id FROM playlists ORDER BY name'
             ).fetchall()
-        return [str(row['name']) for row in rows]
+        by_sid: dict[str, list[str]] = {}
+        standalone: list[str] = []
+        for row in rows:
+            name = str(row['name'])
+            sid = str(row['spotify_id'] or '').strip()
+            if sid:
+                by_sid.setdefault(sid, []).append(name)
+            elif not is_spotify_id(name):
+                standalone.append(name)
+        chosen: set[str] = set(standalone)
+        for names in by_sid.values():
+            human = [name for name in names if not is_spotify_id(name)]
+            chosen.add(sorted(human or names)[0])
+        return sorted(chosen)
 
     def list_playlists_with_spotify_id(self) -> list[dict[str, Any]]:
         """Playlists in the catalog that have a linked Spotify playlist id."""

--- a/downtify/track_index.py
+++ b/downtify/track_index.py
@@ -21,6 +21,12 @@ _SPOTIFY_TRACK_URL = re.compile(
 )
 
 
+def is_spotify_id(value: str) -> bool:
+    """True when *value* is a 22-char Spotify track/playlist id."""
+
+    return bool(_SPOTIFY_TRACK_ID.fullmatch(str(value or '').strip()))
+
+
 def normalize_spotify_track_id(song: dict[str, Any]) -> Optional[str]:
     """Return a 22-char Spotify track id when ``song`` has one, else ``None``."""
 

--- a/frontend/src/i18n/locales/en.js
+++ b/frontend/src/i18n/locales/en.js
@@ -142,6 +142,7 @@ export default {
     subtitle: "Music you've already downloaded. Listen, re-download or remove.",
     searchPlaceholder: 'Search title, artist, album, or path…',
     searchNoResults: 'No tracks match your search.',
+    clearFilters: 'Clear filters',
     empty: 'No downloads yet.',
     emptyHint: 'Find a song to start filling your library.',
     failedLoad: 'Failed to load downloads.',

--- a/frontend/src/i18n/locales/es.js
+++ b/frontend/src/i18n/locales/es.js
@@ -146,6 +146,7 @@ export default {
       'Música que ya has descargado. Escucha, descarga otra vez o elimina.',
     searchPlaceholder: 'Buscar título, artista, álbum o ruta…',
     searchNoResults: 'Ninguna pista coincide con la búsqueda.',
+    clearFilters: 'Quitar filtros',
     empty: 'Aún no hay descargas.',
     emptyHint: 'Encuentra una canción para empezar a llenar tu biblioteca.',
     failedLoad: 'No se pudieron cargar las descargas.',

--- a/frontend/src/i18n/locales/pt-BR.js
+++ b/frontend/src/i18n/locales/pt-BR.js
@@ -143,6 +143,7 @@ export default {
     subtitle: 'Músicas que você já baixou. Escute, baixe novamente ou remova.',
     searchPlaceholder: 'Buscar título, artista, álbum ou caminho…',
     searchNoResults: 'Nenhuma faixa corresponde à busca.',
+    clearFilters: 'Limpar filtros',
     empty: 'Nenhum download ainda.',
     emptyHint: 'Encontre uma música para começar a montar sua biblioteca.',
     failedLoad: 'Falha ao carregar os downloads.',

--- a/frontend/src/views/Downloads.vue
+++ b/frontend/src/views/Downloads.vue
@@ -83,7 +83,10 @@
       </p>
 
       <!-- Playlist filter + bulk selection -->
-      <div v-if="totalItems > 0" class="mb-4 flex flex-wrap items-center gap-2">
+      <div
+        v-if="playlistNames.length > 0 || playlistFilter"
+        class="mb-4 flex flex-wrap items-center gap-2"
+      >
         <label class="text-xs text-base-content/50 shrink-0">
           {{ t('library.filterByPlaylist') }}
         </label>
@@ -150,6 +153,13 @@
         <p class="text-base-content/50 text-sm">
           {{ t('library.searchNoResults') }}
         </p>
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost rounded-full mt-4"
+          @click="clearAllFilters"
+        >
+          {{ t('library.clearFilters') }}
+        </button>
       </div>
 
       <!-- Empty library -->
@@ -415,6 +425,11 @@ function coverUrlFor(file) {
 
 function markCoverFailed(file) {
   coverFailed.value = { ...coverFailed.value, [file]: true }
+}
+
+function clearAllFilters() {
+  clearLibraryFilter()
+  playlistFilter.value = ''
 }
 
 function scheduleLoad() {

--- a/tests/test_playlist_catalog.py
+++ b/tests/test_playlist_catalog.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from downtify.library_catalog import _resolve_playlist_filter_name
 from downtify.playlist_catalog import PlaylistCatalog
 from downtify.track_index import normalize_spotify_track_id
 
@@ -35,3 +36,31 @@ def test_update_filename_by_content_key(tmp_path: Path) -> None:
     names = catalog.update_filename_by_content_key(ck, 'new/t.mp3')
     assert 'Pl' in names
     assert catalog.list_tracks('Pl')[0]['filename'] == 'new/t.mp3'
+
+
+def test_list_playlist_names_prefers_human_title_over_spotify_id(
+    tmp_path: Path,
+) -> None:
+    catalog = PlaylistCatalog(tmp_path / 'lib.db')
+    sid = '4uLU6hMCjMI75M1A2tKUQC'
+    catalog.ensure_playlist(sid, spotify_id=sid)
+    catalog.ensure_playlist('Road Trip', spotify_id=sid)
+    assert catalog.list_playlist_names() == ['Road Trip']
+
+
+def test_resolve_playlist_filter_maps_id_alias_to_named_playlist(
+    tmp_path: Path,
+) -> None:
+    catalog = PlaylistCatalog(tmp_path / 'lib.db')
+    track = tmp_path / 'Artist - Song.mp3'
+    track.write_bytes(b'audio')
+    sid = '4uLU6hMCjMI75M1A2tKUQC'
+    song = {'song_id': '6habFhsOp2NvshLv26DqMb'}
+    catalog.ensure_playlist(sid, spotify_id=sid)
+    catalog.replace_playlist_tracks(
+        'Road Trip',
+        [(song, 'Artist - Song.mp3', track)],
+        spotify_id=sid,
+    )
+    assert _resolve_playlist_filter_name(catalog, sid) == 'Road Trip'
+    assert _resolve_playlist_filter_name(catalog, 'Road Trip') == 'Road Trip'


### PR DESCRIPTION
## Summary
- Hide raw Spotify playlist IDs from the Library playlist dropdown when a human-readable title exists for the same playlist
- Resolve ID aliases when filtering tracks so selecting an old alias still finds the right files
- Fetch playlist title from Spotify on batch download instead of falling back to the playlist ID immediately
- Keep the playlist filter visible when a filter is active but returns 0 tracks, and add a **Clear filters** action

## Problem
The catalog could store Spotify playlist IDs (22-char strings) as playlist names. Selecting those empty aliases returned no tracks, hid the playlist dropdown (`totalItems === 0`), and left the UI stuck on "No tracks match your search."

## Test plan
- [x] `uv run pytest tests/test_playlist_catalog.py`
- [ ] Library page: playlist dropdown shows titles, not bare IDs
- [ ] Selecting a playlist with tracks lists them; **Clear filters** / **All playlists** recovers from empty filter state

Made with [Cursor](https://cursor.com)