### PR TITLE
fix: honor slskd-only audio provider selection

### DIFF
--- a/downtify/api.py
+++ b/downtify/api.py
@@ -455,16 +455,31 @@ def _effective_audio_providers(settings: dict[str, Any]) -> list[str]:
             out.append(p)
     if not out:
         return ['youtube', 'youtube-music']
-    # UI historically stored a single provider; keep playlist downloads useful
-    # by falling back to YouTube when slskd is selected without a backup.
-    if 'slskd' in out and not any(
-        p in out for p in ('youtube', 'youtube-music')
-    ):
-        for fallback in ('youtube', 'youtube-music'):
-            if fallback not in seen:
-                seen.add(fallback)
-                out.append(fallback)
     return out
+
+
+def _validate_audio_providers_settings(settings: dict[str, Any]) -> None:
+    raw = settings.get('audio_providers')
+    if not isinstance(raw, list):
+        return
+    selected = [str(p or '').strip() for p in raw if str(p or '').strip()]
+    if not selected:
+        raise HTTPException(
+            status_code=400,
+            detail='Select at least one audio provider',
+        )
+    allowed = {'youtube-music', 'youtube', 'slskd'}
+    if not any(p in allowed for p in selected):
+        raise HTTPException(
+            status_code=400,
+            detail='Select at least one audio provider',
+        )
+    slskd_cfg = _effective_slskd_settings(settings)
+    if 'slskd' in selected and not bool(slskd_cfg.get('enabled')):
+        raise HTTPException(
+            status_code=400,
+            detail='Enable slskd before selecting it as a download source',
+        )
 
 
 def _playlist_audio_providers_override(
@@ -3074,6 +3089,7 @@ async def write_playlist_m3u_endpoint(request: Request) -> dict[str, Any]:
 @router.get('/api/settings')
 def get_settings_endpoint(client_id: str = Query('')) -> dict[str, Any]:
     out = dict(state.settings)
+    out['audio_providers'] = _effective_audio_providers(state.settings)
     out['youtube'] = _youtube_settings_for_response(state.settings)
     return out
 
@@ -3129,6 +3145,8 @@ async def update_settings_endpoint(
                         status_code=400,
                         detail='Navidrome password is required when enabled',
                     )
+        if 'audio_providers' in payload:
+            _validate_audio_providers_settings(state.settings)
         if 'audio_providers' in payload or 'slskd' in payload:
             state.settings['audio_providers'] = _effective_audio_providers(
                 state.settings

--- a/frontend/src/components/Settings.vue
+++ b/frontend/src/components/Settings.vue
@@ -914,7 +914,8 @@ watchEffect(() => {
 
 const availableAudioProviders = computed(() =>
   sm.settingsOptions.audio_providers.filter(
-    (provider) => provider !== 'slskd' || Boolean(sm.settings.value?.slskd?.enabled)
+    (provider) =>
+      provider !== 'slskd' || Boolean(sm.settings.value?.slskd?.enabled)
   )
 )
 

--- a/frontend/src/components/Settings.vue
+++ b/frontend/src/components/Settings.vue
@@ -60,7 +60,7 @@
           </p>
           <div class="grid grid-cols-2 gap-2">
             <button
-              v-for="provider in sm.settingsOptions.audio_providers"
+              v-for="provider in availableAudioProviders"
               :key="provider"
               type="button"
               class="rounded-xl border px-3 py-2 text-sm transition-colors text-left relative"
@@ -903,6 +903,20 @@ watchEffect(() => {
     sm.settings.value.audio_providers = ['youtube-music']
   }
 })
+
+watchEffect(() => {
+  const slskdOn = Boolean(sm.settings.value?.slskd?.enabled)
+  const list = sm.settings.value?.audio_providers
+  if (!Array.isArray(list) || slskdOn || !list.includes('slskd')) return
+  const next = list.filter((provider) => provider !== 'slskd')
+  sm.settings.value.audio_providers = next.length ? next : ['youtube-music']
+})
+
+const availableAudioProviders = computed(() =>
+  sm.settingsOptions.audio_providers.filter(
+    (provider) => provider !== 'slskd' || Boolean(sm.settings.value?.slskd?.enabled)
+  )
+)
 
 async function onYoutubeCookiesFile(event) {
   const input = event.target

--- a/frontend/src/model/settings.js
+++ b/frontend/src/model/settings.js
@@ -3,7 +3,7 @@ import { ref, computed } from 'vue'
 import API from '/src/model/api'
 
 const settings = ref({
-  audio_providers: [''],
+  audio_providers: ['youtube-music', 'youtube'],
   youtube: {
     cookies_file: '',
     cookies_from_browser: '',
@@ -91,7 +91,15 @@ export function useSettingsManager() {
   const saveErrorText = ref('')
 
   function validateSettings() {
+    const providers = settings.value?.audio_providers || []
+    const selected = providers.filter((p) => String(p || '').trim())
+    if (!selected.length) {
+      return 'Select at least one audio provider'
+    }
     const slskd = settings.value?.slskd || {}
+    if (selected.includes('slskd') && !slskd.enabled) {
+      return 'Enable slskd before selecting it as a download source'
+    }
     if (slskd.enabled) {
       if (!String(slskd.base_url || '').trim()) {
         return 'slskd base URL is required when enabled'
@@ -131,6 +139,21 @@ export function useSettingsManager() {
       .then((res) => {
         if (res.status === 200) {
           console.log('Saved!')
+          if (res.data) {
+            settings.value = {
+              ...settings.value,
+              ...res.data,
+              youtube: {
+                ...settings.value.youtube,
+                ...(res.data.youtube || {}),
+              },
+              slskd: { ...settings.value.slskd, ...(res.data.slskd || {}) },
+              navidrome: {
+                ...settings.value.navidrome,
+                ...(res.data.navidrome || {}),
+              },
+            }
+          }
           isSaved.value = true
           const modal = document.getElementById('settings-modal')
           if (modal && 'checked' in modal) {

--- a/tests/test_api_settings.py
+++ b/tests/test_api_settings.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 
 import json
 
+import pytest
+from fastapi import HTTPException
+
 from downtify.api import (
     DEFAULT_SETTINGS,
     _effective_audio_providers,
     _effective_lyrics_providers,
     _effective_slskd_settings,
     _load_settings,
+    _validate_audio_providers_settings,
 )
 
 
@@ -78,16 +82,12 @@ def test_effective_audio_providers_filters_invalid_and_dedupes():
     ]
 
 
-def test_effective_audio_providers_adds_youtube_fallback_when_only_slskd():
+def test_effective_audio_providers_keeps_slskd_only_when_enabled():
     settings = {
         'audio_providers': ['slskd'],
         'slskd': {'enabled': True},
     }
-    assert _effective_audio_providers(settings) == [
-        'slskd',
-        'youtube',
-        'youtube-music',
-    ]
+    assert _effective_audio_providers(settings) == ['slskd']
 
 
 def test_effective_audio_providers_skips_slskd_when_disabled():
@@ -100,6 +100,42 @@ def test_effective_audio_providers_skips_slskd_when_disabled():
 
 def test_effective_audio_providers_defaults_when_missing():
     assert _effective_audio_providers({}) == ['youtube', 'youtube-music']
+
+
+def test_validate_audio_providers_rejects_empty_selection():
+    with pytest.raises(HTTPException) as exc:
+        _validate_audio_providers_settings({'audio_providers': []})
+    assert exc.value.status_code == 400
+
+
+def test_validate_audio_providers_rejects_slskd_when_disabled():
+    with pytest.raises(HTTPException) as exc:
+        _validate_audio_providers_settings({
+            'audio_providers': ['slskd'],
+            'slskd': {'enabled': False},
+        })
+    assert exc.value.status_code == 400
+
+
+def test_validate_audio_providers_allows_slskd_only_when_enabled():
+    _validate_audio_providers_settings({
+        'audio_providers': ['slskd'],
+        'slskd': {'enabled': True},
+    })
+
+
+def test_load_settings_preserves_slskd_only_audio_providers(tmp_path):
+    path = tmp_path / 'settings.json'
+    path.write_text(
+        json.dumps({
+            'audio_providers': ['slskd'],
+            'slskd': {'enabled': True, 'base_url': 'http://slskd:5030'},
+        }),
+        encoding='utf-8',
+    )
+    out = _load_settings(path)
+    assert out['audio_providers'] == ['slskd']
+    assert _effective_audio_providers(out) == ['slskd']
 
 
 def test_effective_slskd_settings_defaults_when_missing():


### PR DESCRIPTION
## Summary

Fixes the slskd-only download source bug reported in #63.

- Remove backend logic that silently injected `youtube` and `youtube-music` when slskd was the only selected provider (and persisted that mutated list to `settings.json`, which is why YouTube reappeared after restart).
- Validate provider settings on save (at least one source; slskd must be enabled if selected).
- Return the effective provider chain from `GET /api/settings` so the UI matches runtime behavior.
- Settings UI: hide slskd until enabled, drop it from the chain when disabled, and sync state from the save response.

## Issue #63

**YouTube downloads despite slskd-only** — fixed by this PR.

**OGG format but mp3/flac received** — not a bug in provider selection; current behavior:
- The global **Format** setting applies to YouTube downloads (ffmpeg transcode).
- slskd downloads keep the Soulseek file as-is (`leave_in_place`) and are filtered by slskd’s own **extensions** setting (default `mp3`, `flac`), not the global format picker.

Users who want slskd-only + OGG would need either slskd `extensions` to include `ogg` and peers serving OGG, or a future transcoding step for slskd files. Out of scope for this PR.

## Test plan

- [x] `uv run pytest tests/test_api_settings.py`
- [ ] Settings → select only slskd (with slskd enabled) → save → restart stack → confirm YouTube stays deselected
- [ ] Download a track/playlist → confirm no YouTube fallback when slskd-only
- [ ] Disable slskd while it is selected → confirm validation error / slskd removed from chain

Fixes #63 (provider selection part)


Made with [Cursor](https://cursor.com)