### PR TITLE
fix: harden slskd size recovery when browse fails

### DIFF
--- a/downtify/slskd_provider.py
+++ b/downtify/slskd_provider.py
@@ -263,30 +263,71 @@ class SlskdClient:
         return [row for row in data if isinstance(row, dict)]
 
     def remote_file_size(self, username: str, filename: str) -> int:
-        """Browse the peer for the real size (manual overrides carry none).
+        """Resolve peer file size before enqueueing a manual override.
 
-        slskd aborts a transfer when the size it was given does not match
-        the size the peer reports, so an unknown size must be resolved
-        before enqueueing.
+        Prefers a directory browse, then a short targeted search. slskd aborts
+        when the enqueued size does not match what the peer reports.
         """
-        directory = _remote_parent_dir(filename)
-        if not username or not directory:
+        if not username or not filename:
             return 0
-        for entry in self.directory_contents(username, directory):
-            for file_row in entry.get('files') or []:
-                if not isinstance(file_row, dict):
-                    continue
-                name = str(
-                    file_row.get('filename') or file_row.get('fileName') or ''
-                )
-                if not _paths_match(name, filename):
-                    continue
-                try:
-                    size = int(file_row.get('size') or 0)
-                except (TypeError, ValueError):
-                    continue
+        size = self._size_from_directory_browse(username, filename)
+        if size > 0:
+            return size
+        return self._size_from_search(username, filename)
+
+    def _size_from_directory_browse(self, username: str, filename: str) -> int:
+        directory = _remote_parent_dir(filename)
+        if not directory:
+            return 0
+        # Some peers only answer with a trailing separator.
+        candidates = [directory]
+        if not directory.endswith(('\\', '/')):
+            sep = '\\' if '\\' in directory else '/'
+            candidates.append(directory + sep)
+        for directory_name in candidates:
+            for entry in self.directory_contents(username, directory_name):
+                size = _size_from_file_rows(entry.get('files') or [], filename)
                 if size > 0:
                     return size
+        return 0
+
+    def _size_from_search(self, username: str, filename: str) -> int:
+        """Fall back to a short search when directory browse fails (common 500)."""
+        query = _file_basename(filename)
+        if not query:
+            return 0
+        search_id = self.start_search(query) or ''
+        if not search_id:
+            return 0
+        try:
+            polls = min(3, max(1, self.search_retries))
+            interval = min(5, max(1, self.search_poll_seconds))
+            for attempt in range(polls):
+                try:
+                    status = self._request(
+                        'GET', f'/api/v0/searches/{search_id}'
+                    )
+                except Exception:
+                    return 0
+                if isinstance(status, dict) and status.get('isComplete'):
+                    break
+                if attempt + 1 < polls:
+                    time.sleep(interval)
+            for resp in self.search_responses(search_id):
+                if str(resp.get('username') or '').strip() != username:
+                    continue
+                size = _size_from_file_rows(resp.get('files') or [], filename)
+                if size > 0:
+                    logger.info(
+                        'slskd: resolved size={} via search user={!r} '
+                        'file={!r}',
+                        size,
+                        username,
+                        query[:120],
+                    )
+                    return size
+        finally:
+            self.delete_search(search_id)
         return 0
 
     def enqueue_download(self, row: dict[str, Any]) -> bool:
@@ -357,8 +398,15 @@ class SlskdClient:
         return []
 
     def find_transfer(
-        self, username: str, filename: str
+        self,
+        username: str,
+        filename: str,
+        *,
+        ignore_ids: Optional[set[str]] = None,
     ) -> Optional[dict[str, Any]]:
+        """Return the best matching transfer, preferring active over aborted."""
+        ignored = ignore_ids or set()
+        matches: list[dict[str, Any]] = []
         for peer_filter in (username, ''):
             for peer in self.list_download_transfers():
                 if (
@@ -372,14 +420,22 @@ class SlskdClient:
                     for file_row in directory.get('files') or []:
                         if not isinstance(file_row, dict):
                             continue
+                        transfer_id = str(file_row.get('id') or '')
+                        if transfer_id and transfer_id in ignored:
+                            continue
                         name = str(
                             file_row.get('filename')
                             or file_row.get('fileName')
                             or ''
                         )
                         if _paths_match(name, filename):
-                            return file_row
-        return None
+                            matches.append(file_row)
+            if matches:
+                break
+        if not matches:
+            return None
+        active = [row for row in matches if not _transfer_failed(row)]
+        return (active or matches)[0]
 
     def remote_download_directories(self) -> list[str]:
         """Best-effort read of slskd's configured download/incomplete dirs."""
@@ -401,6 +457,24 @@ def _remote_parent_dir(filename: str) -> str:
     if cut <= 0:
         return ''
     return text[:cut]
+
+
+def _size_from_file_rows(rows: Any, filename: str) -> int:
+    if not isinstance(rows, list):
+        return 0
+    for file_row in rows:
+        if not isinstance(file_row, dict):
+            continue
+        name = str(file_row.get('filename') or file_row.get('fileName') or '')
+        if not _paths_match(name, filename):
+            continue
+        try:
+            size = int(file_row.get('size') or 0)
+        except (TypeError, ValueError):
+            continue
+        if size > 0:
+            return size
+    return 0
 
 
 def _enqueue_failures(data: Any) -> list[str]:
@@ -1262,7 +1336,7 @@ def _retry_with_remote_size(
     return remote_size
 
 
-def _wait_for_slskd_file(
+def _wait_for_slskd_file(  # noqa: PLR0914
     client: SlskdClient,
     song: dict[str, Any],
     username: str,
@@ -1293,6 +1367,7 @@ def _wait_for_slskd_file(
     last_progress = wait_started
     last_reported_pct = -1.0
     size_retried = False
+    ignore_ids: set[str] = set()
 
     for attempt in range(max(1, attempts)):
         if deadline is not None and _past_deadline(deadline):
@@ -1322,7 +1397,9 @@ def _wait_for_slskd_file(
                     progress_cb(92.0, 'slskd · downloading', 'slskd')
                 return found
 
-        transfer = client.find_transfer(username, filename)
+        transfer = client.find_transfer(
+            username, filename, ignore_ids=ignore_ids
+        )
         if transfer:
             try:
                 expected_size = max(
@@ -1331,9 +1408,17 @@ def _wait_for_slskd_file(
             except (TypeError, ValueError):
                 pass
             if _transfer_failed(transfer):
+                abort_id = str(transfer.get('id') or '')
                 if size_retried:
-                    return None
+                    # Stale abort still listed after re-enqueue — keep waiting
+                    # for the replacement transfer.
+                    if abort_id:
+                        ignore_ids.add(abort_id)
+                    time.sleep(max(1, interval))
+                    continue
                 size_retried = True
+                if abort_id:
+                    ignore_ids.add(abort_id)
                 expected_size = _retry_with_remote_size(
                     client,
                     transfer,

--- a/tests/test_slskd_override.py
+++ b/tests/test_slskd_override.py
@@ -190,6 +190,83 @@ def test_remote_file_size_browses_peer_directory(monkeypatch):
     assert calls[0][2] == {'directory': '@@wibgr\\Album'}
 
 
+def test_remote_file_size_falls_back_to_search(monkeypatch):
+    client = SlskdClient({
+        'base_url': 'http://slskd:5030',
+        'api_key': 'k',
+        'search_retries': 1,
+        'search_poll_seconds': 1,
+    })
+    monkeypatch.setattr(client, 'directory_contents', lambda *a, **k: [])
+    monkeypatch.setattr(client, 'start_search', lambda q: 'search-1')
+    monkeypatch.setattr(
+        client,
+        '_request',
+        lambda method, path, **kw: {'isComplete': True},
+    )
+    monkeypatch.setattr(
+        client,
+        'search_responses',
+        lambda search_id: [
+            {
+                'username': 'misticgris',
+                'files': [
+                    {
+                        'filename': (
+                            '@@xjjro\\MUSIC\\Mantra (Elfenberg Remix).mp3'
+                        ),
+                        'size': 12_345_678,
+                    }
+                ],
+            }
+        ],
+    )
+    deleted: list[str] = []
+    monkeypatch.setattr(client, 'delete_search', deleted.append)
+
+    size = client.remote_file_size(
+        'misticgris',
+        '@@xjjro\\MUSIC\\Mantra (Elfenberg Remix).mp3',
+    )
+    assert size == 12_345_678
+    assert deleted == ['search-1']
+
+
+def test_find_transfer_prefers_active_over_aborted():
+    client = SlskdClient({'base_url': 'http://slskd:5030', 'api_key': 'k'})
+    client.list_download_transfers = lambda: [  # type: ignore[method-assign]
+        {
+            'username': 'misticgris',
+            'directories': [
+                {
+                    'files': [
+                        {
+                            'id': 'abort-1',
+                            'filename': '@@x\\Mantra.mp3',
+                            'state': 'Completed, Aborted',
+                            'size': 0,
+                        },
+                        {
+                            'id': 'ok-1',
+                            'filename': '@@x\\Mantra.mp3',
+                            'state': 'InProgress',
+                            'size': 123,
+                        },
+                    ]
+                }
+            ],
+        }
+    ]
+    row = client.find_transfer('misticgris', '@@x\\Mantra.mp3')
+    assert row is not None
+    assert row['id'] == 'ok-1'
+    ignored = client.find_transfer(
+        'misticgris', '@@x\\Mantra.mp3', ignore_ids={'ok-1'}
+    )
+    assert ignored is not None
+    assert ignored['id'] == 'abort-1'
+
+
 def test_manual_override_resolves_missing_size_before_enqueue(
     monkeypatch, tmp_path: Path
 ):
@@ -261,28 +338,40 @@ def test_wait_reenqueues_with_remote_size_after_mismatch(
 ):
     monkeypatch.setattr('downtify.slskd_provider.time.sleep', lambda _s: None)
     enqueued: list[dict[str, Any]] = []
-    transfers = [
-        {
-            'id': 'abort-1',
-            'state': 'Completed, Aborted',
-            'exception': (
-                'Transfer aborted: the remote size of 36988402 does not '
-                'match expected size 0'
-            ),
-            'bytesTransferred': 0,
-            'size': 0,
-        },
-        {
-            'id': 'ok-1',
-            'state': 'InProgress',
-            'bytesTransferred': 36988402,
-            'size': 36988402,
-            'percentComplete': 100,
-        },
-    ]
+    aborted = {
+        'id': 'abort-1',
+        'state': 'Completed, Aborted',
+        'exception': (
+            'Transfer aborted: the remote size of 36988402 does not '
+            'match expected size 0'
+        ),
+        'bytesTransferred': 0,
+        'size': 0,
+    }
+    active = {
+        'id': 'ok-1',
+        'state': 'InProgress',
+        'bytesTransferred': 36988402,
+        'size': 36988402,
+        'percentComplete': 100,
+    }
+    # After retry, slskd often still lists the aborted transfer first.
+    transfers = [aborted, aborted, active]
 
     client = MagicMock()
-    client.find_transfer.side_effect = lambda user, name: transfers.pop(0)
+
+    def _find(
+        user: str, name: str, ignore_ids: Any = None
+    ) -> dict[str, Any] | None:
+        ignored = ignore_ids or set()
+        while transfers:
+            row = transfers.pop(0)
+            if str(row.get('id') or '') in ignored:
+                continue
+            return row
+        return None
+
+    client.find_transfer.side_effect = _find
     client.enqueue_download.side_effect = lambda row: bool(
         enqueued.append(dict(row)) or True
     )
@@ -291,12 +380,12 @@ def test_wait_reenqueues_with_remote_size_after_mismatch(
     found.write_bytes(b'0')
     calls = {'n': 0}
 
-    def _find(*_args: Any, **_kwargs: Any) -> Any:
+    def _find_disk(*_args: Any, **_kwargs: Any) -> Any:
         calls['n'] += 1
-        return found if calls['n'] > 1 else None
+        return found if calls['n'] > 2 else None
 
     monkeypatch.setattr(
-        'downtify.slskd_provider._find_on_disk_for_song', _find
+        'downtify.slskd_provider._find_on_disk_for_song', _find_disk
     )
     monkeypatch.setattr(
         'downtify.slskd_provider._disk_complete',


### PR DESCRIPTION
## Summary
Follow-up to #73, which landed before this hardening was ready. A real manual override showed the directory browse returning `500 Internal Server Error` from the peer, leaving the size unresolved and the transfer stuck on the mismatch-retry path.

- fall back to a short targeted search when the directory browse fails, so the peer's size is still resolved before enqueueing
- also try the parent directory with a trailing separator, which some peers require
- prefer active transfers over aborted ones when polling, so a stale `Completed, Aborted` row no longer wins
- ignore the aborted transfer id after a size-mismatch re-enqueue, so the wait loop keeps waiting for the replacement instead of giving up

## Test plan
- [ ] CI: Ruff and pytest
- [ ] CI: frontend Vitest and Prettier
- [ ] Manually retry the override that logged `directory browse failed ... 500` and confirm either `resolved size=... via search` or `size mismatch, re-enqueueing ...` followed by a completed download

Made with [Cursor](https://cursor.com)