### PR TITLE
fix: normalize remote variant markers

### DIFF
--- a/downtify/track_tag_match.py
+++ b/downtify/track_tag_match.py
@@ -45,34 +45,31 @@ _WRONG_MATCH_TITLE_KEYWORDS = (
 # Variant modifiers (live, remix, karaoke, …) shared by YouTube and slskd.
 # Use word-boundary-ish patterns for short tokens (live, remix) to avoid
 # false positives inside unrelated words (e.g. "Oliver", "deliver").
-_UNWANTED_REMOTE_VARIANT_KEYWORDS = (
-    'karaoke',
-    'instrumental',
-    'acapella',
-    'a cappella',
-    'cover ',
-    'cover)',
-    'tribute',
-    'guitar lesson',
-    'sped up',
-    'slowed',
-    'reverb',
-    'nightcore',
-    '8d audio',
-    'bass boosted',
-    ' remix',
-    '(remix',
-    'remix)',
-    'extended',
-    ' clean',
-    'clean version',
-    ' live',
-    '- live',
-    '(live',
-    'live)',
-    'live version',
-    'live at',
-    'live from',
+_UNWANTED_REMOTE_VARIANT_GROUPS = (
+    ('karaoke',),
+    ('instrumental',),
+    ('acapella', 'a cappella'),
+    ('cover ', 'cover)'),
+    ('tribute',),
+    ('guitar lesson',),
+    ('sped up',),
+    ('slowed',),
+    ('reverb',),
+    ('nightcore',),
+    ('8d audio',),
+    ('bass boosted',),
+    (' remix', '(remix', 'remix)'),
+    ('extended',),
+    (' clean', 'clean version'),
+    (
+        ' live',
+        '- live',
+        '(live',
+        'live)',
+        'live version',
+        'live at',
+        'live from',
+    ),
 )
 
 
@@ -91,10 +88,15 @@ def remote_adds_unwanted_variant(
     spotify_blob = f'{spotify_title or ""} {artists}'.casefold()
     remote_l = str(remote_text or '').casefold()
     skip = skip_keywords or frozenset()
-    return any(
-        kw not in skip and kw in remote_l and kw not in spotify_blob
-        for kw in _UNWANTED_REMOTE_VARIANT_KEYWORDS
-    )
+    for markers in _UNWANTED_REMOTE_VARIANT_GROUPS:
+        active = tuple(marker for marker in markers if marker not in skip)
+        if not active:
+            continue
+        if any(marker in remote_l for marker in active) and not any(
+            marker in spotify_blob for marker in markers
+        ):
+            return True
+    return False
 
 
 def _remote_adds_spam_keyword(spotify_title: str, remote_text: str) -> bool:

--- a/tests/test_slskd_responses.py
+++ b/tests/test_slskd_responses.py
@@ -77,6 +77,35 @@ def test_rank_accepts_radio_mix_filename_for_radio_mix_track():
     assert len(ranked) == 1
 
 
+def test_rank_accepts_parenthesized_named_remix():
+    song = {
+        'artists': ['Neyoud', 'Billy Esteban'],
+        'name': 'Raml - Billy Esteban Remix',
+        'duration': 516,
+    }
+    responses = [
+        {
+            'username': 'WaaaltyWaaalt',
+            'fileCount': 1,
+            'hasFreeUploadSlot': True,
+            'files': [
+                {
+                    'filename': (
+                        '@@share\\Neyoud, Billy Esteban - '
+                        'Raml (Billy Esteban Remix).mp3'
+                    ),
+                    'size': 20_140_000,
+                    'length': 516,
+                    'bitRate': 320,
+                },
+            ],
+        },
+    ]
+    ranked = _rank_slskd_candidates(song, responses, {})
+    assert len(ranked) == 1
+    assert ranked[0]['match_score'] >= _match_min_score({})
+
+
 def test_collect_matching_files_skips_wrong_extension_and_keywords():
     song = {
         'artists': ['Melxdie'],

--- a/tests/test_track_tag_match.py
+++ b/tests/test_track_tag_match.py
@@ -226,6 +226,25 @@ def test_remote_text_unacceptable_unifies_spam_and_variants():
     )
 
 
+def test_named_remix_allows_parenthesized_remote_title():
+    spotify = 'Raml - Billy Esteban Remix'
+    remote = 'Neyoud - Raml (Billy Esteban Remix)'
+    assert not remote_adds_unwanted_variant(spotify, remote)
+    assert not remote_text_unacceptable(
+        spotify,
+        remote,
+        spotify_artists=['Neyoud', 'Billy Esteban'],
+    )
+
+
+def test_parenthesized_remix_is_rejected_for_studio_title():
+    assert remote_adds_unwanted_variant(
+        'Raml',
+        'Neyoud - Raml (Billy Esteban Remix)',
+        spotify_artists=['Neyoud'],
+    )
+
+
 def test_remote_adds_unwanted_variant_does_not_match_live_inside_oliver():
     assert not remote_adds_unwanted_variant(
         'Song',


### PR DESCRIPTION
## Summary
A Spotify title such as `Raml - Billy Esteban Remix` was incorrectly rejecting `Neyoud - Raml (Billy Esteban Remix)` because the remote-only punctuation marker `remix)` was compared literally.

- group punctuation forms of remix, live, cover, clean, and acapella into semantic variants
- allow a remote variant when Spotify contains any equivalent marker in that group
- continue rejecting remixes when the Spotify track is the studio/original version
- cover the reported title through both shared filtering and slskd candidate ranking

## Test plan
- [ ] CI: Ruff and pytest
- [ ] CI: frontend Vitest and Prettier
- [ ] Retry `Raml - Billy Esteban Remix` and confirm the parenthesized slskd/YouTube result is accepted

Made with [Cursor](https://cursor.com)