### PR TITLE
fix: use plain keyword audio searches

### DIFF
--- a/downtify/providers.py
+++ b/downtify/providers.py
@@ -19,6 +19,7 @@ from .track_tag_match import (
     media_duration_matches_mix_variant,
     media_duration_matches_song,
     mix_variant_remote_skip_keywords,
+    normalize_search_keywords,
     remote_text_unacceptable,
     strip_mix_suffix,
 )
@@ -239,13 +240,13 @@ def find_match(  # noqa: PLR0914
     """
 
     artists = song.get('artists') or []
-    artists_q = ' '.join(artists)
+    artists_q = normalize_search_keywords(' '.join(artists))
     title = song.get('name', '')
-    query = f'{artists_q} {title}'.strip()
+    query = normalize_search_keywords(f'{artists_q} {title}')
     if not query:
         return None, None
     duration = song.get('duration') or 0
-    title_only = title.strip()
+    title_only = normalize_search_keywords(title)
 
     def _search(
         phase: str, q: str, filt: Optional[str]
@@ -307,9 +308,9 @@ def find_match(  # noqa: PLR0914
             ('match_videos_title_ascii_fold', folded_title, 'videos'),
             ('match_all_title_ascii_fold', folded_title, None),
         ])
-    base_title = strip_mix_suffix(title_only)
+    base_title = normalize_search_keywords(strip_mix_suffix(str(title or '')))
     if base_title and base_title.casefold() != title_only.casefold():
-        base_query = f'{artists_q} {base_title}'.strip()
+        base_query = normalize_search_keywords(f'{artists_q} {base_title}')
         attempts.extend([
             ('match_songs_base_title', base_query, 'songs'),
             ('match_videos_base_title', base_query, 'videos'),
@@ -436,9 +437,9 @@ def find_match_for_video(
     metadata without risking switching to a different track.
     """
 
-    artists = ' '.join(song.get('artists') or [])
+    artists = normalize_search_keywords(' '.join(song.get('artists') or []))
     title = song.get('name', '')
-    query = f'{artists} {title}'.strip()
+    query = normalize_search_keywords(f'{artists} {title}')
     if not query:
         return None
     try:

--- a/downtify/slskd_provider.py
+++ b/downtify/slskd_provider.py
@@ -20,6 +20,7 @@ from .track_tag_match import (
     duration_tolerances_from_settings,
     media_duration_matches_mix_variant,
     media_duration_matches_song,
+    normalize_search_keywords,
     remote_text_unacceptable,
     snapshot_spotify_metadata,
     spotify_file_tag_mismatch_label,
@@ -592,7 +593,7 @@ def _slskd_search_queries(song: dict[str, Any]) -> list[str]:
     seen: set[str] = set()
 
     def add(q: str) -> None:
-        normalized = _normalize_search_text(q)
+        normalized = normalize_search_keywords(q)
         if normalized and normalized not in seen:
             seen.add(normalized)
             queries.append(normalized)

--- a/downtify/slskd_provider.py
+++ b/downtify/slskd_provider.py
@@ -584,7 +584,8 @@ def _slskd_search_queries(song: dict[str, Any]) -> list[str]:
         for a in (song.get('artists') or [])[:2]
         if str(a).strip()
     ]
-    artist = artists[0] if artists else ''
+    all_artists = ' '.join(artists)
+    primary_artist = artists[0] if artists else ''
     title = str(song.get('name') or '').strip()
     short_title = _primary_title(title)
     queries: list[str] = []
@@ -596,17 +597,26 @@ def _slskd_search_queries(song: dict[str, Any]) -> list[str]:
             seen.add(normalized)
             queries.append(normalized)
 
-    # Explo uses "title - artist"
-    if short_title and artist:
-        add(f'{short_title} - {artist}')
-    if title and artist and title != short_title:
-        add(f'{title} - {artist}')
-    if short_title:
+    # Soulseek search is keyword-oriented. Start with up to two credited
+    # artists, then progressively remove terms so a strict query cannot hide
+    # results.
+    if all_artists and title:
+        add(f'{all_artists} {title}')
+    if all_artists and short_title and short_title != title:
+        add(f'{all_artists} {short_title}')
+    if primary_artist and title and primary_artist != all_artists:
+        add(f'{primary_artist} {title}')
+    if (
+        primary_artist
+        and short_title
+        and short_title != title
+        and primary_artist != all_artists
+    ):
+        add(f'{primary_artist} {short_title}')
+    if title:
+        add(title)
+    if short_title and short_title != title:
         add(short_title)
-    if artist and short_title and short_title != title:
-        add(f'{artist} {short_title}')
-    if artist and title:
-        add(f'{artist} {title}')
     return queries
 
 

--- a/downtify/track_tag_match.py
+++ b/downtify/track_tag_match.py
@@ -161,6 +161,14 @@ def strip_mix_suffix(title: str) -> str:
     return _MIX_SUFFIX_RE.sub('', str(title or '').strip()).strip()
 
 
+def normalize_search_keywords(text: str) -> str:
+    """Convert metadata text to plain search keywords without punctuation."""
+
+    normalized = unicodedata.normalize('NFKC', str(text or ''))
+    normalized = re.sub(r"[''`\u2019]", '', normalized)
+    return re.sub(r'[\W_]+', ' ', normalized).strip()
+
+
 def candidate_adds_mix_variant(
     spotify_title: str, candidate_title: str
 ) -> bool:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -149,6 +149,34 @@ def test_find_match_falls_back_when_song_rows_have_no_video_id(monkeypatch):
     assert match['videoId'] == 'abc123def45'
 
 
+def test_find_match_uses_plain_keyword_queries(monkeypatch):
+    queries: list[str] = []
+
+    class FakeYTM:
+        @staticmethod
+        def search(query, filter=None, limit=10):
+            queries.append(query)
+            if filter == 'songs':
+                return [
+                    {
+                        'title': "Don't Touch (Extended Mix)",
+                        'videoId': 'plain123456',
+                        'duration_seconds': 240,
+                    }
+                ]
+            return []
+
+    monkeypatch.setattr(providers, '_ytm', FakeYTM)
+    video_id, _match = providers.find_match({
+        'name': "Don't Touch - Extended Mix",
+        'artists': ['Y:K'],
+        'duration': 240,
+    })
+    assert video_id == 'plain123456'
+    assert queries[0] == 'Y K Dont Touch Extended Mix'
+    assert all(not any(char in query for char in ":()'-") for query in queries)
+
+
 def test_youtube_title_rejects_live_when_spotify_is_studio():
     assert youtube_title_has_negative_keyword(
         'Old Man River',

--- a/tests/test_slskd_responses.py
+++ b/tests/test_slskd_responses.py
@@ -32,14 +32,17 @@ def test_flatten_slskd_responses_attaches_username_to_files():
     assert rows[0]['filename'] == 'Artist - Track.mp3'
 
 
-def test_slskd_search_queries_prefers_title_dash_artist():
+def test_slskd_search_queries_prefers_all_artists_then_title():
     queries = _slskd_search_queries({
-        'artists': ['4D4M'],
-        'name': "YOU KNOW WHERE WE'RE GOING - Hardstyle Bass Bounce Edition",
-        'album_name': "YOU KNOW WHERE WE'RE GOING",
+        'artists': ['Facundo Mohrr', 'Valdovinos'],
+        'name': 'No Mod',
+        'album_name': 'Burning',
     })
-    assert queries[0] == 'YOU KNOW WHERE WERE GOING - 4D4M'
-    assert 'YOU KNOW WHERE WERE GOING' in queries
+    assert queries == [
+        'Facundo Mohrr Valdovinos No Mod',
+        'Facundo Mohrr No Mod',
+        'No Mod',
+    ]
 
 
 def test_slskd_search_queries_include_full_and_short_radio_mix():
@@ -47,9 +50,10 @@ def test_slskd_search_queries_include_full_and_short_radio_mix():
         'artists': ['Y:K'],
         'name': 'Loud Enough - Radio Mix',
     })
-    assert queries[0] == 'Loud Enough - Y:K'
-    assert 'Loud Enough - Radio Mix - Y:K' in queries
+    assert queries[0] == 'Y:K Loud Enough - Radio Mix'
+    assert 'Y:K Loud Enough' in queries
     assert 'Y:K Loud Enough - Radio Mix' in queries
+    assert 'Loud Enough' in queries
 
 
 def test_rank_accepts_radio_mix_filename_for_radio_mix_track():

--- a/tests/test_slskd_responses.py
+++ b/tests/test_slskd_responses.py
@@ -50,10 +50,10 @@ def test_slskd_search_queries_include_full_and_short_radio_mix():
         'artists': ['Y:K'],
         'name': 'Loud Enough - Radio Mix',
     })
-    assert queries[0] == 'Y:K Loud Enough - Radio Mix'
-    assert 'Y:K Loud Enough' in queries
-    assert 'Y:K Loud Enough - Radio Mix' in queries
+    assert queries[0] == 'Y K Loud Enough Radio Mix'
+    assert 'Y K Loud Enough' in queries
     assert 'Loud Enough' in queries
+    assert all(not any(char in query for char in ':()-') for query in queries)
 
 
 def test_rank_accepts_radio_mix_filename_for_radio_mix_track():

--- a/tests/test_track_tag_match.py
+++ b/tests/test_track_tag_match.py
@@ -9,6 +9,7 @@ from downtify.track_tag_match import (
     duration_tolerances_from_settings,
     media_duration_matches_mix_variant,
     media_duration_matches_song,
+    normalize_search_keywords,
     remote_adds_unwanted_variant,
     remote_text_unacceptable,
     remote_title_unacceptable,
@@ -150,6 +151,13 @@ def test_duration_tolerances_from_slskd_settings():
 def test_strip_mix_suffix():
     assert strip_mix_suffix('Loud Enough - Radio Mix') == 'Loud Enough'
     assert strip_mix_suffix('Heat - Extended Mix') == 'Heat'
+
+
+def test_normalize_search_keywords_removes_punctuation():
+    assert (
+        normalize_search_keywords("Y:K - Don't Touch (Extended Mix)")
+        == 'Y K Dont Touch Extended Mix'
+    )
 
 
 def test_candidate_adds_mix_variant_last_resort_only():


### PR DESCRIPTION
## Summary
Search requests should be retrieval-oriented keywords, not punctuation-preserving metadata. For `No Mod` by Facundo Mohrr and Valdovinos, the direct Soulseek query `Facundo Mohrr Valdovinos No Mod` finds the expected files.

- start slskd searches with up to two credited artists and the full title
- progressively broaden to shortened-title, primary-artist, and title-only fallbacks
- remove punctuation from both slskd and YouTube Music match queries
- preserve Unicode letters and numbers while converting separators to spaces
- keep original metadata unchanged for candidate validation and tagging

## Examples
- `No Mod` by Facundo Mohrr and Valdovinos → `Facundo Mohrr Valdovinos No Mod`
- `Don't Touch - Extended Mix` by Y:K → `Y K Dont Touch Extended Mix`

## Test plan
- [ ] CI: Ruff and pytest
- [ ] CI: frontend Vitest and Prettier
- [ ] Retry `No Mod` and confirm the first slskd query returns the expected candidate
- [ ] Confirm a punctuated artist/title uses plain keyword queries in YouTube matching