### PR TITLE
fix: trust manual slskd override over tag check

### DIFF
--- a/downtify/slskd_provider.py
+++ b/downtify/slskd_provider.py
@@ -1525,6 +1525,30 @@ def _slskd_override_row(song: dict[str, Any]) -> Optional[dict[str, Any]]:
     return {'username': username, 'filename': filename, 'size': max(0, size)}
 
 
+def _log_manual_override_tag_difference(
+    found: Path, spotify_row: dict[str, Any], filename: str
+) -> None:
+    """Note tag differences on a manual pick without rejecting the file.
+
+    The user chose this exact remote file, so their intent outranks the
+    automatic tag comparison used for search-based candidates.
+    """
+    if verify_downloaded_file_matches_spotify(found, spotify_row):
+        return
+    meta = read_audio_metadata(found)
+    mismatch_row = {
+        **spotify_row,
+        'name': str(meta.get('title') or ''),
+        'artists': list(meta.get('artists') or []),
+        'library_from_tags': True,
+    }
+    logger.info(
+        'slskd: manual override tags differ {}; keeping user pick file={!r}',
+        spotify_file_tag_mismatch_label(mismatch_row),
+        _file_basename(filename)[:120],
+    )
+
+
 def _download_slskd_direct(
     song: dict[str, Any],
     settings: dict[str, Any],
@@ -1648,17 +1672,8 @@ def _download_slskd_direct(
                 leave_in_place=leave_in_place,
                 expected_size=expected_size,
             )
-        if found is not None and not verify_downloaded_file_matches_spotify(
-            found, spotify_row
-        ):
-            logger.info(
-                'slskd: manual override tags mismatch title={!r} file={!r}',
-                song.get('name'),
-                _file_basename(filename)[:120],
-            )
-            _discard_mismatched_download(found)
-            found = None
         if found is not None:
+            _log_manual_override_tag_difference(found, spotify_row, filename)
             return _finalize_slskd_path(found, output_dir, leave_in_place)
     return None
 

--- a/tests/test_slskd_override.py
+++ b/tests/test_slskd_override.py
@@ -129,6 +129,72 @@ def test_download_slskd_direct_skips_search(monkeypatch, tmp_path: Path):
     assert enqueued[0]['filename'].startswith('@@wibgr')
 
 
+def test_download_slskd_direct_keeps_file_when_tags_differ(
+    monkeypatch, tmp_path: Path
+):
+    slskd_dir = tmp_path / 'slskd'
+    slskd_dir.mkdir()
+    track = slskd_dir / '18 - Audiense - Desert Rose (Original Mix).mp3'
+    track.write_bytes(b'0' * 80_000)
+
+    def _fake_client(_settings: dict[str, Any]) -> MagicMock:
+        client = MagicMock()
+        client.configured.return_value = True
+        client.can_connect.return_value = True
+        client.remote_download_directories.return_value = []
+        client.enqueue_download.return_value = True
+        client.find_transfer.return_value = {
+            'state': 'Completed, Succeeded',
+            'bytesTransferred': 80_000,
+            'size': 80_000,
+            'percentComplete': 100,
+        }
+        return client
+
+    monkeypatch.setattr('downtify.slskd_provider.SlskdClient', _fake_client)
+    monkeypatch.setattr(
+        'downtify.slskd_provider._find_on_disk_for_song',
+        lambda *args, **kwargs: track,
+    )
+    monkeypatch.setattr(
+        'downtify.slskd_provider.verify_downloaded_file_matches_spotify',
+        lambda path, row: False,
+    )
+    monkeypatch.setattr(
+        'downtify.slskd_provider.read_audio_metadata',
+        lambda path: {
+            'title': 'Desert Rose (Original Mix)',
+            'artists': ['Audiense'],
+        },
+    )
+    monkeypatch.setattr(
+        'downtify.slskd_provider._slskd_semaphore',
+        lambda settings: MagicMock(
+            __enter__=lambda self: self, __exit__=lambda *a: None
+        ),
+    )
+
+    settings = {
+        'enabled': True,
+        'source_dir': str(slskd_dir),
+        'output_dir': str(tmp_path / 'downloads'),
+        'leave_in_place': True,
+    }
+    song = {
+        'name': 'Desert Rose (DOTB Deepdub) - Mixed',
+        'artists': ['Audiense'],
+        'slskd_override': True,
+        'slskd_username': 'Zambererronni',
+        'slskd_filename': (
+            '@@x\\Album\\18 - Audiense - Desert Rose (Original Mix).mp3'
+        ),
+        'slskd_size': 80_000,
+    }
+
+    assert _download_slskd_direct(song, settings) == track
+    assert track.is_file()
+
+
 def test_remote_parent_dir_handles_soulseek_separators():
     assert (
         _remote_parent_dir('@@wibgr\\Album\\06 - Track.mp3')


### PR DESCRIPTION
## Summary
A hand-picked slskd file was downloaded successfully, then deleted by the automatic tag comparison. Spotify listed `Audiense - Desert Rose (DOTB Deepdub) - Mixed` while the chosen file's tags read `Audiense - Desert Rose (Original Mix)`, so the job ended with `No audio source` even though the user had explicitly selected that exact remote file.

- keep the downloaded file when a manual override's tags differ from Spotify
- log the difference (`manual override tags differ ...; keeping user pick`) so the mismatch is still visible
- leave verification and next-candidate rejection untouched for search-based candidates

## Test plan
- [ ] CI: Ruff and pytest
- [ ] CI: frontend Vitest and Prettier
- [x] `pytest tests/test_slskd_override.py tests/test_slskd_responses.py` passes, including a new case asserting a tag-mismatched manual pick is kept on disk
- [ ] Re-run the `Desert Rose (DOTB Deepdub) - Mixed` override and confirm it completes instead of being discarded

Made with [Cursor](https://cursor.com)