### PR TITLE
fix: slskd edit-tag match and single search query

### DIFF
--- a/downtify/slskd_provider.py
+++ b/downtify/slskd_provider.py
@@ -580,45 +580,42 @@ def _discard_mismatched_download(path: Path) -> None:
 
 
 def _slskd_search_queries(song: dict[str, Any]) -> list[str]:
+    """Build a single Soulseek keyword query for *song*.
+
+    Soulseek matches are AND over tokens, so one well-chosen query beats a
+    cascade of progressively looser searches. Use the primary artist plus the
+    mix-stripped title; append album only when the title is too short to stand
+    alone.
+    """
     artists = [
         str(a).strip()
-        for a in (song.get('artists') or [])[:2]
+        for a in (song.get('artists') or [])
         if str(a).strip()
     ]
-    all_artists = ' '.join(artists)
     primary_artist = artists[0] if artists else ''
-    title = str(song.get('name') or '').strip()
-    short_title = _primary_title(title)
-    queries: list[str] = []
-    seen: set[str] = set()
+    raw_title = str(song.get('name') or '').strip()
+    title = _primary_title(raw_title) or raw_title
+    album = str(song.get('album_name') or '').strip()
 
-    def add(q: str) -> None:
-        normalized = normalize_search_keywords(q)
-        if normalized and normalized not in seen:
-            seen.add(normalized)
-            queries.append(normalized)
-
-    # Soulseek search is keyword-oriented. Start with up to two credited
-    # artists, then progressively remove terms so a strict query cannot hide
-    # results.
-    if all_artists and title:
-        add(f'{all_artists} {title}')
-    if all_artists and short_title and short_title != title:
-        add(f'{all_artists} {short_title}')
-    if primary_artist and title and primary_artist != all_artists:
-        add(f'{primary_artist} {title}')
-    if (
-        primary_artist
-        and short_title
-        and short_title != title
-        and primary_artist != all_artists
-    ):
-        add(f'{primary_artist} {short_title}')
+    parts: list[str] = []
+    if primary_artist:
+        parts.append(primary_artist)
     if title:
-        add(title)
-    if short_title and short_title != title:
-        add(short_title)
-    return queries
+        parts.append(title)
+
+    title_tokens = [
+        token for token in normalize_search_keywords(title).split() if token
+    ]
+    short_ambiguous = (
+        bool(album)
+        and len(title_tokens) == 1
+        and len(title_tokens[0]) <= 5
+    )
+    if short_ambiguous:
+        parts.append(album)
+
+    query = normalize_search_keywords(' '.join(parts))
+    return [query] if query else []
 
 
 def _file_extension(filename: str) -> str:
@@ -1413,11 +1410,13 @@ def _wait_for_slskd_file(  # noqa: PLR0914
         )
         if transfer:
             try:
-                expected_size = max(
-                    expected_size, int(transfer.get('size') or 0)
-                )
+                xfer_size = int(transfer.get('size') or 0)
             except (TypeError, ValueError):
-                pass
+                xfer_size = 0
+            # Prefer the live transfer size — search results often overestimate,
+            # which makes _disk_complete reject a finished file forever.
+            if xfer_size > 0:
+                expected_size = xfer_size
             if _transfer_failed(transfer):
                 abort_id = str(transfer.get('id') or '')
                 if size_retried:
@@ -1445,7 +1444,12 @@ def _wait_for_slskd_file(  # noqa: PLR0914
                 time.sleep(max(1, interval))
                 continue
             transferred = int(transfer.get('bytesTransferred') or 0)
-            if transferred > last_bytes:
+            if _transfer_succeeded(transfer):
+                # Finished in slskd — keep polling disk; do not stall-timeout
+                # a completed transfer whose file has not appeared yet.
+                last_bytes = max(last_bytes, transferred)
+                last_progress = time.monotonic()
+            elif transferred > last_bytes:
                 last_bytes = transferred
                 last_progress = time.monotonic()
             elif time.monotonic() - last_progress > queued_timeout:

--- a/downtify/track_tag_match.py
+++ b/downtify/track_tag_match.py
@@ -137,9 +137,17 @@ def youtube_title_has_negative_keyword(
     return remote_adds_unwanted_variant(spotify_title, candidate_title)
 
 
+# Trailing dash-suffixes: "Song - Radio Edit", "Song - Edit", "Song - Remix".
 _MIX_SUFFIX_RE = re.compile(
     r'\s*[-–—]\s*(?:radio\s+(?:mix|edit)|extended\s+mix|club\s+mix|'
-    r'original\s+mix|clean\s+version|explicit\s+version|remix)\s*$',
+    r'original\s+mix|clean\s+version|explicit\s+version|remix|'
+    r'rework(?:\s+radio\s+edit)?|edit)\s*$',
+    re.IGNORECASE,
+)
+# Trailing parentheticals with mix labels:
+# "Osama (Bruno Be, Ralk Rework Radio Edit)".
+_MIX_PAREN_RE = re.compile(
+    r'\s*\([^)]*(?:radio\s+)?(?:mix|edit|rework|remix|version)[^)]*\)\s*$',
     re.IGNORECASE,
 )
 
@@ -158,7 +166,9 @@ MIX_VARIANT_REMOTE_SKIP_KEYWORDS = frozenset({'extended'})
 def strip_mix_suffix(title: str) -> str:
     """Drop trailing mix/edit suffixes for broader audio search queries."""
 
-    return _MIX_SUFFIX_RE.sub('', str(title or '').strip()).strip()
+    text = str(title or '').strip()
+    text = _MIX_PAREN_RE.sub('', text).strip()
+    return _MIX_SUFFIX_RE.sub('', text).strip()
 
 
 def normalize_search_keywords(text: str) -> str:
@@ -245,11 +255,19 @@ def _titles_align(expected: str, from_file: str) -> bool:
     file_title_n = _normalize_tag_loose(from_file)
     if not title_n or not file_title_n:
         return True
-    return (
+    if (
         title_n == file_title_n
         or title_n in file_title_n
         or file_title_n in title_n
-    )
+    ):
+        return True
+    # Spotify often uses "Song - Edit" while Soulseek tags keep the full
+    # mix label ("Song (… Rework Radio Edit)"). Compare mix-stripped cores.
+    exp_core = _normalize_tag_loose(strip_mix_suffix(expected))
+    file_core = _normalize_tag_loose(strip_mix_suffix(from_file))
+    if not exp_core or not file_core:
+        return False
+    return exp_core == file_core
 
 
 def _artist_lists_align(expected: list[str], actual: list[str]) -> bool:

--- a/tests/test_slskd_responses.py
+++ b/tests/test_slskd_responses.py
@@ -32,28 +32,38 @@ def test_flatten_slskd_responses_attaches_username_to_files():
     assert rows[0]['filename'] == 'Artist - Track.mp3'
 
 
-def test_slskd_search_queries_prefers_all_artists_then_title():
+def test_slskd_search_queries_single_primary_artist_and_title():
     queries = _slskd_search_queries({
         'artists': ['Facundo Mohrr', 'Valdovinos'],
         'name': 'No Mod',
         'album_name': 'Burning',
     })
-    assert queries == [
-        'Facundo Mohrr Valdovinos No Mod',
-        'Facundo Mohrr No Mod',
-        'No Mod',
-    ]
+    assert queries == ['Facundo Mohrr No Mod']
 
 
-def test_slskd_search_queries_include_full_and_short_radio_mix():
+def test_slskd_search_queries_strips_mix_suffix_to_core_title():
     queries = _slskd_search_queries({
         'artists': ['Y:K'],
         'name': 'Loud Enough - Radio Mix',
     })
-    assert queries[0] == 'Y K Loud Enough Radio Mix'
-    assert 'Y K Loud Enough' in queries
-    assert 'Loud Enough' in queries
-    assert all(not any(char in query for char in ':()-') for query in queries)
+    assert queries == ['Y K Loud Enough']
+
+
+def test_slskd_search_queries_strips_edit_and_uses_primary_artist():
+    queries = _slskd_search_queries({
+        'artists': ['Zakes Bantwini', 'Kasango'],
+        'name': 'Osama - Edit',
+    })
+    assert queries == ['Zakes Bantwini Osama']
+
+
+def test_slskd_search_queries_appends_album_for_short_title():
+    queries = _slskd_search_queries({
+        'artists': ['Artist'],
+        'name': 'You',
+        'album_name': 'Debut',
+    })
+    assert queries == ['Artist You Debut']
 
 
 def test_rank_accepts_radio_mix_filename_for_radio_mix_track():

--- a/tests/test_slskd_timeout.py
+++ b/tests/test_slskd_timeout.py
@@ -49,6 +49,63 @@ def test_wait_for_slskd_file_queued_timeout_without_transfer(monkeypatch):
     assert client.find_transfer.called
 
 
+def test_wait_for_slskd_file_completed_transfer_not_stalled(
+    monkeypatch, tmp_path: Path
+):
+    """A finished slskd transfer must not stall-timeout before the file appears."""
+    client = MagicMock()
+    client.find_transfer.return_value = {
+        'id': 't1',
+        'state': 'Completed, Succeeded',
+        'size': 1000,
+        'bytesTransferred': 1000,
+        'bytesRemaining': 0,
+        'percentComplete': 100,
+    }
+
+    target = tmp_path / 'file.mp3'
+    calls = {'n': 0}
+
+    def fake_find(*_a, **_k):
+        calls['n'] += 1
+        if calls['n'] < 3:
+            return None
+        target.write_bytes(b'x' * 1000)
+        return target
+
+    monkeypatch.setattr(
+        'downtify.slskd_provider.time.sleep', lambda _s: None
+    )
+    monkeypatch.setattr(
+        'downtify.slskd_provider._find_on_disk_for_song', fake_find
+    )
+
+    clock = {'t': 1000.0}
+
+    def tick() -> float:
+        clock['t'] += 5.0
+        return clock['t']
+
+    monkeypatch.setattr('downtify.slskd_provider.time.monotonic', tick)
+
+    result = _wait_for_slskd_file(
+        client,
+        {'name': 'Song'},
+        'peer',
+        'file.mp3',
+        {
+            'poll_interval_seconds': 1,
+            'poll_max_attempts': 10,
+            # Would fire on a completed transfer under the old stall logic.
+            'queued_timeout_seconds': 2,
+        },
+        [tmp_path],
+        expected_size=1000,
+        deadline=1600.0,
+    )
+    assert result == target
+
+
 def test_resolve_video_id_falls_back_after_slskd_timeout(
     monkeypatch, tmp_path
 ):

--- a/tests/test_track_tag_match.py
+++ b/tests/test_track_tag_match.py
@@ -151,6 +151,41 @@ def test_duration_tolerances_from_slskd_settings():
 def test_strip_mix_suffix():
     assert strip_mix_suffix('Loud Enough - Radio Mix') == 'Loud Enough'
     assert strip_mix_suffix('Heat - Extended Mix') == 'Heat'
+    assert strip_mix_suffix('Osama - Edit') == 'Osama'
+    assert (
+        strip_mix_suffix('Osama (Bruno Be, Ralk Rework Radio Edit)') == 'Osama'
+    )
+
+
+def test_titles_align_edit_vs_rework_radio_edit():
+    """Spotify 'Edit' labels must match Soulseek full mix parentheticals."""
+    assert spotify_aligns_with_file_tags({
+        'spotify_name': 'Osama - Edit',
+        'spotify_artists': ['Zakes Bantwini', 'Kasango'],
+        'name': 'Osama (Bruno Be, Ralk Rework Radio Edit)',
+        'artists': ['Bruno Be', 'Kasango', 'Ralk'],
+        'library_from_tags': True,
+    })
+
+
+def test_verify_accepts_edit_vs_rework_radio_edit_tags(
+    monkeypatch, tmp_path: Path
+) -> None:
+    path = tmp_path / 'osama.flac'
+    path.write_bytes(b'x')
+    monkeypatch.setattr(
+        'downtify.track_tag_match.read_audio_metadata',
+        lambda _p: {
+            'title': 'Osama (Bruno Be, Ralk Rework Radio Edit)',
+            'artists': ['Bruno Be', 'Kasango', 'Ralk'],
+            'album': '',
+        },
+    )
+    spotify_row = snapshot_spotify_metadata({
+        'name': 'Osama - Edit',
+        'artists': ['Zakes Bantwini', 'Kasango'],
+    })
+    assert verify_downloaded_file_matches_spotify(path, spotify_row)
 
 
 def test_normalize_search_keywords_removes_punctuation():


### PR DESCRIPTION
## Summary
- Accept Spotify `Edit` / mix labels that align with Soulseek full titles (e.g. `Osama - Edit` vs `Osama (… Rework Radio Edit)`), so successful slskd downloads are not discarded and YouTube is not wrongly tried next.
- Use a single Soulseek search query (`primary artist` + mix-stripped core title; album only for short titles) instead of cascading up to six queries.
- Do not stall-timeout a `Completed` transfer while waiting for the file on disk; trust the live transfer size over inflated search sizes.

## Test plan
- [ ] Unit tests: `uv run pytest tests/test_track_tag_match.py tests/test_slskd_timeout.py tests/test_slskd_responses.py -q`
- [ ] Download a Spotify track titled like `… - Edit` that exists on Soulseek with a longer mix parenthetical; confirm Downtify keeps the slskd file and does not fall back to YouTube
- [ ] Confirm logs show one `slskd` search query per track (primary artist + core title)


Made with [Cursor](https://cursor.com)