### PR TITLE
fix: include named remixer in slskd search query

### DIFF
--- a/downtify/slskd_provider.py
+++ b/downtify/slskd_provider.py
@@ -20,6 +20,7 @@ from .track_tag_match import (
     duration_tolerances_from_settings,
     media_duration_matches_mix_variant,
     media_duration_matches_song,
+    named_remixer,
     normalize_search_keywords,
     remote_text_unacceptable,
     snapshot_spotify_metadata,
@@ -584,8 +585,8 @@ def _slskd_search_queries(song: dict[str, Any]) -> list[str]:
 
     Soulseek matches are AND over tokens, so one well-chosen query beats a
     cascade of progressively looser searches. Use the primary artist plus the
-    mix-stripped title; append album only when the title is too short to stand
-    alone.
+    mix-stripped title; append a named remixer when present; append album only
+    when the title is too short to stand alone.
     """
     artists = [
         str(a).strip()
@@ -595,6 +596,7 @@ def _slskd_search_queries(song: dict[str, Any]) -> list[str]:
     primary_artist = artists[0] if artists else ''
     raw_title = str(song.get('name') or '').strip()
     title = _primary_title(raw_title) or raw_title
+    remixer = named_remixer(raw_title)
     album = str(song.get('album_name') or '').strip()
 
     parts: list[str] = []
@@ -602,6 +604,11 @@ def _slskd_search_queries(song: dict[str, Any]) -> list[str]:
         parts.append(primary_artist)
     if title:
         parts.append(title)
+    # Named remixes are filed under the remixer more often than the original
+    # artist — keep both when they differ.
+    if remixer and _alnum_only(remixer) != _alnum_only(primary_artist):
+        if _alnum_only(remixer) not in _alnum_only(title):
+            parts.append(remixer)
 
     title_tokens = [
         token for token in normalize_search_keywords(title).split() if token

--- a/downtify/track_tag_match.py
+++ b/downtify/track_tag_match.py
@@ -144,10 +144,19 @@ _MIX_SUFFIX_RE = re.compile(
     r'rework(?:\s+radio\s+edit)?|edit)\s*$',
     re.IGNORECASE,
 )
+# Named remix dash: "Yuma (Se Se Se Se) - Francis Mercier Remix".
+_NAMED_REMIX_DASH_RE = re.compile(
+    r'\s*[-–—]\s*(?P<remixer>.+?)\s+remix\s*$',
+    re.IGNORECASE,
+)
 # Trailing parentheticals with mix labels:
 # "Osama (Bruno Be, Ralk Rework Radio Edit)".
 _MIX_PAREN_RE = re.compile(
     r'\s*\([^)]*(?:radio\s+)?(?:mix|edit|rework|remix|version)[^)]*\)\s*$',
+    re.IGNORECASE,
+)
+_NAMED_REMIX_PAREN_RE = re.compile(
+    r'\((?P<remixer>[^)]+?)\s+remix\)\s*$',
     re.IGNORECASE,
 )
 
@@ -163,10 +172,24 @@ _MIX_VARIANT_MARKERS = (
 MIX_VARIANT_REMOTE_SKIP_KEYWORDS = frozenset({'extended'})
 
 
+def named_remixer(title: str) -> str:
+    """Return the remixer name from a titled remix, or '' if none."""
+
+    text = str(title or '').strip()
+    match = _NAMED_REMIX_DASH_RE.search(text)
+    if match:
+        return match.group('remixer').strip()
+    match = _NAMED_REMIX_PAREN_RE.search(text)
+    if match:
+        return match.group('remixer').strip()
+    return ''
+
+
 def strip_mix_suffix(title: str) -> str:
     """Drop trailing mix/edit suffixes for broader audio search queries."""
 
     text = str(title or '').strip()
+    text = _NAMED_REMIX_DASH_RE.sub('', text).strip()
     text = _MIX_PAREN_RE.sub('', text).strip()
     return _MIX_SUFFIX_RE.sub('', text).strip()
 

--- a/tests/test_slskd_responses.py
+++ b/tests/test_slskd_responses.py
@@ -57,6 +57,19 @@ def test_slskd_search_queries_strips_edit_and_uses_primary_artist():
     assert queries == ['Zakes Bantwini Osama']
 
 
+def test_slskd_search_queries_includes_named_remixer():
+    queries = _slskd_search_queries({
+        'artists': [
+            'Miishu',
+            'Emmanuel Jal',
+            'Francis Mercier',
+            'Nyadollar',
+        ],
+        'name': 'Yuma (Se Se Se Se) - Francis Mercier Remix',
+    })
+    assert queries == ['Miishu Yuma Se Se Se Se Francis Mercier']
+
+
 def test_slskd_search_queries_appends_album_for_short_title():
     queries = _slskd_search_queries({
         'artists': ['Artist'],

--- a/tests/test_track_tag_match.py
+++ b/tests/test_track_tag_match.py
@@ -168,7 +168,7 @@ def test_named_remixer_from_dash_and_paren():
         == 'Francis Mercier'
     )
     assert named_remixer('Raml (Billy Esteban Remix)') == 'Billy Esteban'
-    assert named_remixer('Osama - Edit') == ''
+    assert not named_remixer('Osama - Edit')
 
 
 def test_titles_align_edit_vs_rework_radio_edit():

--- a/tests/test_track_tag_match.py
+++ b/tests/test_track_tag_match.py
@@ -9,6 +9,7 @@ from downtify.track_tag_match import (
     duration_tolerances_from_settings,
     media_duration_matches_mix_variant,
     media_duration_matches_song,
+    named_remixer,
     normalize_search_keywords,
     remote_adds_unwanted_variant,
     remote_text_unacceptable,
@@ -155,6 +156,19 @@ def test_strip_mix_suffix():
     assert (
         strip_mix_suffix('Osama (Bruno Be, Ralk Rework Radio Edit)') == 'Osama'
     )
+    assert (
+        strip_mix_suffix('Yuma (Se Se Se Se) - Francis Mercier Remix')
+        == 'Yuma (Se Se Se Se)'
+    )
+
+
+def test_named_remixer_from_dash_and_paren():
+    assert (
+        named_remixer('Yuma (Se Se Se Se) - Francis Mercier Remix')
+        == 'Francis Mercier'
+    )
+    assert named_remixer('Raml (Billy Esteban Remix)') == 'Billy Esteban'
+    assert named_remixer('Osama - Edit') == ''
 
 
 def test_titles_align_edit_vs_rework_radio_edit():


### PR DESCRIPTION
## Summary
- Detect named remix suffixes (`- Artist Remix` / `(Artist Remix)`) and append the remixer to the single slskd keyword query.
- Example: `Yuma (Se Se Se Se) - Francis Mercier Remix` → `Miishu Yuma Se Se Se Se Francis Mercier`.

## Test plan
- [ ] `uv run pytest tests/test_track_tag_match.py tests/test_slskd_responses.py -q`
- [ ] Download a named-remix Spotify track; confirm logs show remixer keywords in the slskd search query


Made with [Cursor](https://cursor.com)