### PR TITLE
fix: accept Extended Mix for Spotify Original Mix tracks

### DIFF
--- a/downtify/slskd_provider.py
+++ b/downtify/slskd_provider.py
@@ -24,6 +24,7 @@ from .track_tag_match import (
     remote_text_unacceptable,
     snapshot_spotify_metadata,
     spotify_file_tag_mismatch_label,
+    spotify_title_has_mix_label,
     strip_mix_suffix,
     verify_downloaded_file_matches_spotify,
 )
@@ -645,8 +646,12 @@ def _contains_keyword(
     if segments:
         # Immediate parent folder (e.g. "Artist - Album") — not the whole tree.
         haystacks.append(segments[-1])
+    # Spotify "Original Mix" vs Soulseek "Extended Mix" (and similar swaps)
+    # should not be hard-rejected when the playlist already asked for a mix cut.
     skip = (
-        MIX_VARIANT_REMOTE_SKIP_KEYWORDS if allow_mix_variants else frozenset()
+        MIX_VARIANT_REMOTE_SKIP_KEYWORDS
+        if allow_mix_variants or spotify_title_has_mix_label(title)
+        else frozenset()
     )
     return any(
         remote_text_unacceptable(
@@ -903,6 +908,9 @@ def _rank_slskd_candidates(
 ) -> list[dict[str, Any]]:
     """Score and sort all viable files (highest confidence first)."""
     target_duration = _song_duration_seconds(song)
+    mix_duration = allow_mix_variants or spotify_title_has_mix_label(
+        str(song.get('name') or '')
+    )
     ranked: list[dict[str, Any]] = []
 
     for resp in _filter_slskd_responses(responses):
@@ -938,7 +946,7 @@ def _rank_slskd_candidates(
                 filename,
                 file_row,
                 target_duration=target_duration,
-                mix_variant_duration=allow_mix_variants,
+                mix_variant_duration=mix_duration,
                 settings=settings,
             )
             if scored is None:

--- a/downtify/track_tag_match.py
+++ b/downtify/track_tag_match.py
@@ -383,16 +383,21 @@ def media_duration_matches_mix_variant(
     target = song_duration_seconds(song)
     if not target:
         return media_seconds <= _MAX_WHEN_SPOTIFY_DURATION_UNKNOWN
-    # Hard cap: reject audiobook-length outliers.
     if media_seconds > max(720, int(target * 2.5)):
         return False
     if media_seconds < max(20, int(target * 0.35)) and target >= 60:
         return False
-    # Original Mix (~3–7m) vs Extended Mix (often ~2x) is normal on Soulseek.
-    if media_seconds >= int(target * 0.85) and media_seconds <= int(
-        target * 2.5
-    ):
-        return True
+    spotify_title = str(song.get('spotify_name') or song.get('name') or '')
+    # Spotify already asked for a mix cut (Original/Radio/…) — Extended on
+    # Soulseek is often ~2x and should still match. Do not apply this window
+    # to plain studio titles (YouTube last-resort Extended probes).
+    if spotify_title_has_mix_label(spotify_title):
+        if media_seconds >= int(target * 0.85) and media_seconds <= int(
+            target * 2.5
+        ):
+            return True
+    elif media_seconds > int(target * 1.85) + 30:
+        return False
     return abs(media_seconds - target) <= max(
         90, int(target * tolerance_percent / 100)
     )

--- a/downtify/track_tag_match.py
+++ b/downtify/track_tag_match.py
@@ -163,6 +163,13 @@ _MIX_VARIANT_MARKERS = (
 MIX_VARIANT_REMOTE_SKIP_KEYWORDS = frozenset({'extended'})
 
 
+def spotify_title_has_mix_label(title: str) -> bool:
+    """True when Spotify already names a mix/edit cut (Original, Extended, …)."""
+
+    folded = str(title or '').casefold()
+    return any(marker in folded for marker in _MIX_VARIANT_MARKERS)
+
+
 def strip_mix_suffix(title: str) -> str:
     """Drop trailing mix/edit suffixes for broader audio search queries."""
 
@@ -376,12 +383,16 @@ def media_duration_matches_mix_variant(
     target = song_duration_seconds(song)
     if not target:
         return media_seconds <= _MAX_WHEN_SPOTIFY_DURATION_UNKNOWN
+    # Hard cap: reject audiobook-length outliers.
     if media_seconds > max(720, int(target * 2.5)):
-        return False
-    if media_seconds > int(target * 1.85) + 30:
         return False
     if media_seconds < max(20, int(target * 0.35)) and target >= 60:
         return False
+    # Original Mix (~3–7m) vs Extended Mix (often ~2x) is normal on Soulseek.
+    if media_seconds >= int(target * 0.85) and media_seconds <= int(
+        target * 2.5
+    ):
+        return True
     return abs(media_seconds - target) <= max(
         90, int(target * tolerance_percent / 100)
     )

--- a/tests/test_slskd_responses.py
+++ b/tests/test_slskd_responses.py
@@ -91,6 +91,38 @@ def test_rank_accepts_radio_mix_filename_for_radio_mix_track():
     assert len(ranked) == 1
 
 
+def test_rank_accepts_extended_mix_for_original_mix_track():
+    """Spotify Original Mix should keep Extended Mix hits instead of YouTube."""
+    song = {
+        'artists': ['Simone Vitullo', 'David Herrero', 'Shrii'],
+        'name': 'Higher - Original Mix',
+        'duration': 180,
+    }
+    filename = (
+        r'@@huuiq\8\2021\2021 (06) Jun\\'
+        r'Simone Vitullo, David Herrero, Shrii - Higher (Extended Mix).mp3'
+    )
+    responses = [
+        {
+            'username': 'Deees2811',
+            'fileCount': 1,
+            'hasFreeUploadSlot': True,
+            'files': [
+                {
+                    'filename': filename,
+                    'size': 15_000_000,
+                    'length': 360,
+                    'bitRate': 320,
+                },
+            ],
+        },
+    ]
+    assert _contains_keyword(song, filename) is False
+    ranked = _rank_slskd_candidates(song, responses, {})
+    assert len(ranked) == 1
+    assert ranked[0]['username'] == 'Deees2811'
+
+
 def test_rank_accepts_parenthesized_named_remix():
     song = {
         'artists': ['Neyoud', 'Billy Esteban'],

--- a/tests/test_track_tag_match.py
+++ b/tests/test_track_tag_match.py
@@ -105,7 +105,15 @@ def test_media_duration_accepts_mix_variant_last_resort_drift():
     song = {'duration': 210}
     assert media_duration_matches_song(song, 260) is False
     assert media_duration_matches_mix_variant(song, 260) is True
-    assert media_duration_matches_mix_variant(song, 380) is False
+    # Original (~3.5m) → Extended (~2x) should pass; 3x+ still rejected.
+    assert media_duration_matches_mix_variant(song, 420) is True
+    assert media_duration_matches_mix_variant(song, 600) is False
+
+
+def test_media_duration_accepts_original_vs_extended_double_length():
+    song = {'duration': 180}
+    assert media_duration_matches_song(song, 360) is False
+    assert media_duration_matches_mix_variant(song, 360) is True
 
 
 def test_media_duration_respects_custom_tolerance_percent():

--- a/tests/test_track_tag_match.py
+++ b/tests/test_track_tag_match.py
@@ -102,18 +102,19 @@ def test_media_duration_accepts_short_track_youtube_padding():
 
 
 def test_media_duration_accepts_mix_variant_last_resort_drift():
-    song = {'duration': 210}
+    song = {'duration': 210, 'name': 'Heat'}
     assert media_duration_matches_song(song, 260) is False
     assert media_duration_matches_mix_variant(song, 260) is True
-    # Original (~3.5m) → Extended (~2x) should pass; 3x+ still rejected.
-    assert media_duration_matches_mix_variant(song, 420) is True
-    assert media_duration_matches_mix_variant(song, 600) is False
+    # Studio title → long Extended remains rejected.
+    assert media_duration_matches_mix_variant(song, 380) is False
 
 
 def test_media_duration_accepts_original_vs_extended_double_length():
-    song = {'duration': 180}
+    song = {'duration': 180, 'name': 'Higher - Original Mix'}
     assert media_duration_matches_song(song, 360) is False
     assert media_duration_matches_mix_variant(song, 360) is True
+    assert media_duration_matches_mix_variant(song, 420) is True
+    assert media_duration_matches_mix_variant(song, 600) is False
 
 
 def test_media_duration_respects_custom_tolerance_percent():


### PR DESCRIPTION
## Summary
- When Spotify already names a mix cut (`Original Mix`, `Radio Mix`, etc.), do not hard-reject Soulseek `Extended Mix` (and similar) filenames.
- Loosen mix-variant duration matching so Original (~3–7m) vs Extended (~2x) still ranks instead of falling back to YouTube.
- Covers cases like `Higher - Original Mix` matching `Higher (Extended Mix).mp3` that completed in slskd while Downtify continued on YouTube.

## Test plan
- [ ] `uv run pytest tests/test_track_tag_match.py tests/test_slskd_responses.py -q`
- [ ] Download a Spotify `… - Original Mix` track that only has an Extended Mix on Soulseek; confirm Downtify keeps the slskd file and does not switch to YouTube


Made with [Cursor](https://cursor.com)