### PR TITLE
fix: use full Spotify artists + title for slskd search

### DIFF
--- a/downtify/slskd_provider.py
+++ b/downtify/slskd_provider.py
@@ -20,7 +20,6 @@ from .track_tag_match import (
     duration_tolerances_from_settings,
     media_duration_matches_mix_variant,
     media_duration_matches_song,
-    named_remixer,
     normalize_search_keywords,
     remote_text_unacceptable,
     snapshot_spotify_metadata,
@@ -538,7 +537,11 @@ def _alnum_only(text: str) -> str:
 
 
 def _primary_title(title: str) -> str:
+    """Core title for basename matching (mix labels and parentheticals removed)."""
     text = strip_mix_suffix(str(title or '').strip())
+    # Drop hook/parenthetical noise: "Yuma (Se Se Se Se)" → "Yuma".
+    text = re.sub(r'\([^)]*\)', ' ', text)
+    text = re.sub(r'\s+', ' ', text).strip()
     if ' - ' in text:
         head = text.split(' - ', 1)[0].strip()
         if head:
@@ -582,37 +585,28 @@ def _discard_mismatched_download(path: Path) -> None:
 
 
 def _slskd_search_queries(song: dict[str, Any]) -> list[str]:
-    """Build a single Soulseek keyword query for *song*.
+    """Build a single Soulseek keyword query from Spotify artists + title.
 
-    Soulseek matches are AND over tokens, so one well-chosen query beats a
-    cascade of progressively looser searches. Use the primary artist plus the
-    mix-stripped title; append a named remixer when present; append album only
-    when the title is too short to stand alone.
+    Use the playlist metadata as-is (all credited artists and the full track
+    name). Only normalize punctuation — do not invent shorter/stripped
+    variants. Append album when the title alone is too short to disambiguate.
     """
     artists = [
         str(a).strip()
         for a in (song.get('artists') or [])
         if str(a).strip()
     ]
-    primary_artist = artists[0] if artists else ''
     raw_title = str(song.get('name') or '').strip()
-    title = _primary_title(raw_title) or raw_title
-    remixer = named_remixer(raw_title)
     album = str(song.get('album_name') or '').strip()
 
-    parts: list[str] = []
-    if primary_artist:
-        parts.append(primary_artist)
-    if title:
-        parts.append(title)
-    # Named remixes are filed under the remixer more often than the original
-    # artist — keep both when they differ.
-    if remixer and _alnum_only(remixer) != _alnum_only(primary_artist):
-        if _alnum_only(remixer) not in _alnum_only(title):
-            parts.append(remixer)
+    parts: list[str] = [*artists]
+    if raw_title:
+        parts.append(raw_title)
 
     title_tokens = [
-        token for token in normalize_search_keywords(title).split() if token
+        token
+        for token in normalize_search_keywords(raw_title).split()
+        if token
     ]
     short_ambiguous = (
         bool(album)

--- a/downtify/track_tag_match.py
+++ b/downtify/track_tag_match.py
@@ -280,6 +280,10 @@ def _normalize_tag_loose(text: str) -> str:
     return re.sub(r'\s+', ' ', text).strip()
 
 
+def _strip_parentheticals(text: str) -> str:
+    return re.sub(r'\s+', ' ', re.sub(r'\([^)]*\)', ' ', text)).strip()
+
+
 def _titles_align(expected: str, from_file: str) -> bool:
     title_n = _normalize_tag_loose(expected)
     file_title_n = _normalize_tag_loose(from_file)
@@ -295,9 +299,18 @@ def _titles_align(expected: str, from_file: str) -> bool:
     # mix label ("Song (… Rework Radio Edit)"). Compare mix-stripped cores.
     exp_core = _normalize_tag_loose(strip_mix_suffix(expected))
     file_core = _normalize_tag_loose(strip_mix_suffix(from_file))
-    if not exp_core or not file_core:
+    if exp_core and file_core and exp_core == file_core:
+        return True
+    # Parenthetical hooks can differ slightly: "(Se Se Se Se)" vs "(Se Se Se)".
+    exp_bare = _normalize_tag_loose(
+        _strip_parentheticals(strip_mix_suffix(expected))
+    )
+    file_bare = _normalize_tag_loose(
+        _strip_parentheticals(strip_mix_suffix(from_file))
+    )
+    if not exp_bare or not file_bare:
         return False
-    return exp_core == file_core
+    return exp_bare == file_bare
 
 
 def _artist_lists_align(expected: list[str], actual: list[str]) -> bool:

--- a/tests/test_slskd_responses.py
+++ b/tests/test_slskd_responses.py
@@ -32,32 +32,32 @@ def test_flatten_slskd_responses_attaches_username_to_files():
     assert rows[0]['filename'] == 'Artist - Track.mp3'
 
 
-def test_slskd_search_queries_single_primary_artist_and_title():
+def test_slskd_search_queries_uses_all_artists_and_full_title():
     queries = _slskd_search_queries({
         'artists': ['Facundo Mohrr', 'Valdovinos'],
         'name': 'No Mod',
         'album_name': 'Burning',
     })
-    assert queries == ['Facundo Mohrr No Mod']
+    assert queries == ['Facundo Mohrr Valdovinos No Mod']
 
 
-def test_slskd_search_queries_strips_mix_suffix_to_core_title():
+def test_slskd_search_queries_keeps_mix_label_in_title():
     queries = _slskd_search_queries({
         'artists': ['Y:K'],
         'name': 'Loud Enough - Radio Mix',
     })
-    assert queries == ['Y K Loud Enough']
+    assert queries == ['Y K Loud Enough Radio Mix']
 
 
-def test_slskd_search_queries_strips_edit_and_uses_primary_artist():
+def test_slskd_search_queries_keeps_edit_in_title():
     queries = _slskd_search_queries({
         'artists': ['Zakes Bantwini', 'Kasango'],
         'name': 'Osama - Edit',
     })
-    assert queries == ['Zakes Bantwini Osama']
+    assert queries == ['Zakes Bantwini Kasango Osama Edit']
 
 
-def test_slskd_search_queries_includes_named_remixer():
+def test_slskd_search_queries_matches_manual_yuma_search():
     queries = _slskd_search_queries({
         'artists': [
             'Miishu',
@@ -67,7 +67,10 @@ def test_slskd_search_queries_includes_named_remixer():
         ],
         'name': 'Yuma (Se Se Se Se) - Francis Mercier Remix',
     })
-    assert queries == ['Miishu Yuma Se Se Se Se Francis Mercier']
+    assert queries == [
+        'Miishu Emmanuel Jal Francis Mercier Nyadollar '
+        'Yuma Se Se Se Se Francis Mercier Remix'
+    ]
 
 
 def test_slskd_search_queries_appends_album_for_short_title():
@@ -77,6 +80,42 @@ def test_slskd_search_queries_appends_album_for_short_title():
         'album_name': 'Debut',
     })
     assert queries == ['Artist You Debut']
+
+
+def test_rank_accepts_yuma_with_se_count_mismatch():
+    """Spotify (Se Se Se Se) must still match Soulseek (Se Se Se)."""
+    song = {
+        'artists': [
+            'Miishu',
+            'Emmanuel Jal',
+            'Francis Mercier',
+            'Nyadollar',
+        ],
+        'name': 'Yuma (Se Se Se Se) - Francis Mercier Remix',
+        'duration': 196,
+    }
+    filename = (
+        r'music\Singletons\Miishu, Emmanuel Jal, Nyadollar, Francis Mercier\\'
+        r'Yuma (Se Se Se) - Francis Mercier Remix.flac'
+    )
+    responses = [
+        {
+            'username': 'fishingpvalues',
+            'fileCount': 1,
+            'hasFreeUploadSlot': True,
+            'files': [
+                {
+                    'filename': filename,
+                    'size': 25_360_000,
+                    'length': 196,
+                    'bitRate': 0,
+                },
+            ],
+        },
+    ]
+    ranked = _rank_slskd_candidates(song, responses, {})
+    assert len(ranked) == 1
+    assert ranked[0]['username'] == 'fishingpvalues'
 
 
 def test_rank_accepts_radio_mix_filename_for_radio_mix_track():

--- a/tests/test_track_tag_match.py
+++ b/tests/test_track_tag_match.py
@@ -191,6 +191,26 @@ def test_titles_align_edit_vs_rework_radio_edit():
     })
 
 
+def test_titles_align_se_count_mismatch_in_parenthetical():
+    assert spotify_aligns_with_file_tags({
+        'spotify_name': 'Yuma (Se Se Se Se) - Francis Mercier Remix',
+        'spotify_artists': [
+            'Miishu',
+            'Emmanuel Jal',
+            'Francis Mercier',
+            'Nyadollar',
+        ],
+        'name': 'Yuma (Se Se Se) - Francis Mercier Remix',
+        'artists': [
+            'Miishu',
+            'Emmanuel Jal',
+            'Nyadollar',
+            'Francis Mercier',
+        ],
+        'library_from_tags': True,
+    })
+
+
 def test_verify_accepts_edit_vs_rework_radio_edit_tags(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- Build the single slskd query from **all Spotify artists + full track title** (punctuation normalized only), matching what works in the slskd UI.
- Example: `Yuma (Se Se Se Se) - Francis Mercier Remix` → `Miishu Emmanuel Jal Francis Mercier Nyadollar Yuma Se Se Se Se Francis Mercier Remix`
- Ranking/tag verify: treat parenthetical hooks as optional so `(Se Se Se Se)` still matches `(Se Se Se)`.

## Test plan
- [ ] `uv run pytest tests/test_track_tag_match.py tests/test_slskd_responses.py -q`
- [ ] Retry `Yuma (Se Se Se Se) - Francis Mercier Remix`; confirm slskd finds the fishingpvalues FLAC and does not fall back to YouTube


Made with [Cursor](https://cursor.com)