### PR TITLE
fix: retry slskd search on HTTP 429

### DIFF
--- a/downtify/slskd_provider.py
+++ b/downtify/slskd_provider.py
@@ -105,6 +105,8 @@ _PATH_PENALTY_KEYWORDS = (
 _AMBIGUOUS_TITLE_ALNUM_LEN = 5
 _DEFAULT_MATCH_MIN_SCORE = 5
 _STRICT_DURATION_SECONDS = 3
+_SEARCH_TRANSIENT_HTTP = frozenset({429, 502, 503, 504})
+_SEARCH_POST_ATTEMPTS = 4
 
 
 class SlskdClient:
@@ -161,13 +163,46 @@ class SlskdClient:
             'minimumResponseFileCount': 1,
             'minimumPeerUploadSpeed': 1,
         }
-        try:
-            data = self._request('POST', '/api/v0/searches', json_body=body)
-        except Exception as exc:
-            logger.info(
-                'slskd: search POST failed q={!r} err={}', query[:120], exc
-            )
-            return None
+        data: Any = None
+        for attempt in range(_SEARCH_POST_ATTEMPTS):
+            try:
+                data = self._request(
+                    'POST', '/api/v0/searches', json_body=body
+                )
+                break
+            except requests.HTTPError as exc:
+                status = (
+                    exc.response.status_code if exc.response is not None else 0
+                )
+                if (
+                    status in _SEARCH_TRANSIENT_HTTP
+                    and attempt < _SEARCH_POST_ATTEMPTS - 1
+                ):
+                    delay = 2.0 * (attempt + 1)
+                    logger.info(
+                        'slskd: search POST HTTP {} q={!r}, retry {}/{} '
+                        'in {:.0f}s',
+                        status,
+                        query[:120],
+                        attempt + 1,
+                        _SEARCH_POST_ATTEMPTS,
+                        delay,
+                    )
+                    time.sleep(delay)
+                    continue
+                logger.info(
+                    'slskd: search POST failed q={!r} err={}',
+                    query[:120],
+                    exc,
+                )
+                return None
+            except Exception as exc:
+                logger.info(
+                    'slskd: search POST failed q={!r} err={}',
+                    query[:120],
+                    exc,
+                )
+                return None
         if isinstance(data, dict):
             for key in ('id', 'searchId'):
                 raw = data.get(key)
@@ -592,9 +627,7 @@ def _slskd_search_queries(song: dict[str, Any]) -> list[str]:
     variants. Append album when the title alone is too short to disambiguate.
     """
     artists = [
-        str(a).strip()
-        for a in (song.get('artists') or [])
-        if str(a).strip()
+        str(a).strip() for a in (song.get('artists') or []) if str(a).strip()
     ]
     raw_title = str(song.get('name') or '').strip()
     album = str(song.get('album_name') or '').strip()
@@ -612,6 +645,8 @@ def _slskd_search_queries(song: dict[str, Any]) -> list[str]:
         bool(album)
         and len(title_tokens) == 1
         and len(title_tokens[0]) <= 5
+        and normalize_search_keywords(album).casefold()
+        != normalize_search_keywords(raw_title).casefold()
     )
     if short_ambiguous:
         parts.append(album)

--- a/tests/test_slskd_responses.py
+++ b/tests/test_slskd_responses.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import Any
 
+import requests
+
 from downtify.slskd_provider import (
     SlskdClient,
     _collect_matching_files,
@@ -80,6 +82,38 @@ def test_slskd_search_queries_appends_album_for_short_title():
         'album_name': 'Debut',
     })
     assert queries == ['Artist You Debut']
+
+
+def test_slskd_search_queries_skips_album_when_same_as_title():
+    queries = _slskd_search_queries({
+        'artists': ['Redoxx', 'Rex Stax'],
+        'name': 'Nenge',
+        'album_name': 'Nenge',
+    })
+    assert queries == ['Redoxx Rex Stax Nenge']
+
+
+def test_start_search_retries_on_http_429(monkeypatch):
+    client = SlskdClient({
+        'base_url': 'https://slskd.example',
+        'api_key': 'k',
+    })
+    calls = {'n': 0}
+    sleeps: list[float] = []
+
+    def fake_request(method: str, path: str, **kwargs: Any):
+        calls['n'] += 1
+        if calls['n'] < 3:
+            response = requests.models.Response()
+            response.status_code = 429
+            raise requests.HTTPError('429', response=response)
+        return {'id': 'search-ok'}
+
+    monkeypatch.setattr(client, '_request', fake_request)
+    monkeypatch.setattr('downtify.slskd_provider.time.sleep', sleeps.append)
+    assert client.start_search('Artist Title') == 'search-ok'
+    assert calls['n'] == 3
+    assert sleeps == [2.0, 4.0]
 
 
 def test_rank_accepts_yuma_with_se_count_mismatch():


### PR DESCRIPTION
## Summary
- Retry slskd `POST /searches` on 429/502/503/504 (up to 4 attempts, 2s/4s/6s backoff) instead of immediately treating rate limits as “no match”.
- Skip appending album to the query when it equals the title (fixes `Nenge Nenge`).

## Why
Playlist batches start several downloads at once. slskd returns `429 Too Many Requests`; Downtify logged `search POST failed` and fell through to YouTube with no retry.

## Test plan
- [ ] `uv run pytest tests/test_slskd_responses.py -q`
- [ ] Start a multi-track playlist download against a rate-limited slskd; confirm logs show `search POST HTTP 429 … retry` and searches succeed after backoff


Made with [Cursor](https://cursor.com)