### PR TITLE
fix: recover tagging for corrupt Soulseek MP3 ID3 tags

### DIFF
--- a/downtify/downloader.py
+++ b/downtify/downloader.py
@@ -28,6 +28,7 @@ from mutagen.id3 import (
     TRCK,
     USLT,
 )
+from mutagen.id3 import delete as id3_delete
 from mutagen.mp3 import MP3
 from mutagen.mp4 import MP4, MP4Cover
 from mutagen.oggopus import OggOpus
@@ -1312,7 +1313,9 @@ class Downloader:
     ) -> None:
         label = _provider_display_name(provider)
         if progress_cb:
-            msg = f'{label} · tagging metadata' if label else 'Tagging metadata'
+            msg = (
+                f'{label} · tagging metadata' if label else 'Tagging metadata'
+            )
             progress_cb(96.0, msg, provider)
 
         if not song.get('genre'):
@@ -1343,7 +1346,11 @@ class Downloader:
 
         if self.lyrics_providers:
             if progress_cb:
-                lyr_msg = f'{label} · fetching lyrics' if label else 'Fetching lyrics'
+                lyr_msg = (
+                    f'{label} · fetching lyrics'
+                    if label
+                    else 'Fetching lyrics'
+                )
                 progress_cb(97.0, lyr_msg, provider)
             try:
                 fetched = lyrics_mod.fetch(song, self.lyrics_providers)
@@ -1860,6 +1867,74 @@ def embed_metadata(path: Path, song: dict[str, Any]) -> None:
         )
 
 
+def _mpeg_audio_frame_offset(data: bytes) -> int:
+    """Byte offset of the first MPEG audio frame (0 if none found)."""
+
+    start = 0
+    if len(data) >= 10 and data[:3] == b'ID3':
+        size = (
+            ((data[6] & 0x7F) << 21)
+            | ((data[7] & 0x7F) << 14)
+            | ((data[8] & 0x7F) << 7)
+            | (data[9] & 0x7F)
+        )
+        claimed_end = 10 + size
+        # Oversized/corrupt ID3 claims must not skip past EOF.
+        start = 10 if claimed_end > len(data) else claimed_end
+    for i in range(start, max(start, len(data) - 1)):
+        if data[i] == 0xFF and (data[i + 1] & 0xE0) == 0xE0:
+            return i
+    for i in range(0, len(data) - 1):
+        if data[i] == 0xFF and (data[i + 1] & 0xE0) == 0xE0:
+            return i
+    return 0
+
+
+def _strip_mp3_id3_best_effort(path: Path) -> None:
+    """Remove ID3 tags; fall back to MPEG-frame rewrite when mutagen cannot."""
+
+    path_s = str(path)
+    try:
+        id3_delete(path_s)
+        return
+    except Exception:
+        logger.opt(exception=True).debug(
+            'mutagen ID3 delete failed for {}', path.name
+        )
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return
+    offset = _mpeg_audio_frame_offset(data)
+    if offset <= 0:
+        return
+    try:
+        path.write_bytes(data[offset:])
+    except OSError:
+        logger.opt(exception=True).warning(
+            'Could not rewrite MP3 without ID3 for {}', path.name
+        )
+
+
+def _open_mp3_for_tagging(path: Path) -> MP3:
+    """Open an MP3 for tagging; strip corrupt/truncated ID3 headers if needed."""
+
+    path_s = str(path)
+    try:
+        audio = MP3(path_s, ID3=ID3)
+    except Exception as exc:
+        logger.warning(
+            'Corrupt or unreadable ID3 on {}; stripping tags ({})',
+            path.name,
+            exc,
+        )
+        _strip_mp3_id3_best_effort(path)
+        audio = MP3(path_s, ID3=ID3)
+    if audio.tags is None:
+        audio.add_tags()
+    return audio
+
+
 def _tag_mp3(
     path: Path,
     title: str,
@@ -1871,9 +1946,7 @@ def _tag_mp3(
     track_number: Optional[int],
     album_track_total: Optional[int],
 ) -> None:
-    audio = MP3(str(path), ID3=ID3)
-    if audio.tags is None:
-        audio.add_tags()
+    audio = _open_mp3_for_tagging(path)
     audio.tags.delall('APIC')
     audio.tags.add(TIT2(encoding=3, text=title))
     if artists:
@@ -2069,9 +2142,7 @@ def embed_lyrics(path: Path, lyrics: 'lyrics_mod.Lyrics') -> None:
 
     suffix = path.suffix.lower().lstrip('.')
     if suffix == 'mp3':
-        audio = MP3(str(path), ID3=ID3)
-        if audio.tags is None:
-            audio.add_tags()
+        audio = _open_mp3_for_tagging(path)
         audio.tags.delall('USLT')
         audio.tags.add(USLT(encoding=3, lang='eng', desc='', text=text))
         audio.save(v2_version=3)

--- a/tests/test_mp3_corrupt_id3.py
+++ b/tests/test_mp3_corrupt_id3.py
@@ -1,0 +1,100 @@
+"""Recover tagging when Soulseek MP3s ship corrupt/truncated ID3 headers."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from mutagen.id3 import ID3, TIT2
+from mutagen.id3._util import error as ID3Error
+from mutagen.mp3 import MP3
+
+from downtify.downloader import (
+    _mpeg_audio_frame_offset,
+    _open_mp3_for_tagging,
+    embed_metadata,
+)
+
+
+def _synchsafe(size: int) -> bytes:
+    return bytes([
+        (size >> 21) & 0x7F,
+        (size >> 14) & 0x7F,
+        (size >> 7) & 0x7F,
+        size & 0x7F,
+    ])
+
+
+def _ffmpeg_available() -> bool:
+    return shutil.which('ffmpeg') is not None
+
+
+def _write_tiny_mp3(path: Path) -> None:
+    subprocess.run(
+        [
+            'ffmpeg',
+            '-y',
+            '-f',
+            'lavfi',
+            '-i',
+            'anullsrc=r=44100:cl=mono',
+            '-t',
+            '0.2',
+            '-q:a',
+            '9',
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _prepend_corrupt_id3(path: Path) -> None:
+    path.write_bytes(
+        b'ID3\x03\x00\x00' + _synchsafe(351_155) + path.read_bytes()
+    )
+
+
+@pytest.mark.skipif(not _ffmpeg_available(), reason='ffmpeg required')
+def test_open_mp3_strips_oversized_corrupt_id3(tmp_path: Path) -> None:
+    path = tmp_path / 'track.mp3'
+    _write_tiny_mp3(path)
+    _prepend_corrupt_id3(path)
+
+    with pytest.raises(ID3Error):
+        MP3(str(path), ID3=ID3)
+
+    audio = _open_mp3_for_tagging(path)
+    audio.tags.delall('TIT2')
+    audio.tags.add(TIT2(encoding=3, text='Recovered'))
+    audio.save(v2_version=3)
+
+    tagged = MP3(str(path), ID3=ID3)
+    assert str(tagged.tags.get('TIT2')) == 'Recovered'
+
+
+@pytest.mark.skipif(not _ffmpeg_available(), reason='ffmpeg required')
+def test_embed_metadata_recovers_corrupt_id3(tmp_path: Path) -> None:
+    path = tmp_path / 'smile.mp3'
+    _write_tiny_mp3(path)
+    _prepend_corrupt_id3(path)
+    embed_metadata(
+        path,
+        {
+            'name': 'I Just Want You To Smile',
+            'artists': ['Dancing on Lego'],
+            'album_name': 'Single',
+            'year': '2024',
+        },
+    )
+    tagged = MP3(str(path), ID3=ID3)
+    assert 'Smile' in str(tagged.tags.get('TIT2'))
+    assert 'Dancing' in str(tagged.tags.get('TPE1'))
+
+
+def test_mpeg_audio_frame_offset_skips_oversized_id3_claim() -> None:
+    frame = b'\xff\xfb\x90\x00' + b'\x00' * 32
+    data = b'ID3\x03\x00\x00' + _synchsafe(351_155) + frame
+    assert _mpeg_audio_frame_offset(data) == 10


### PR DESCRIPTION
## Summary
- Soulseek MP3s sometimes have truncated/corrupt ID3 headers (claimed tag size larger than the file). mutagen raises `id3.error` and Downtify skipped embedding Spotify metadata.
- On load failure: strip ID3 (mutagen delete, or rewrite from the first MPEG frame), then tag normally.
- Same recovery path for lyrics embedding.

## Test plan
- [ ] `uv run pytest tests/test_mp3_corrupt_id3.py -q`
- [ ] Re-download / re-tag a track like `Dancing On Lego - I Just Want You To Smile` from slskd; confirm metadata embeds without the ID3 traceback


Made with [Cursor](https://cursor.com)