### PR TITLE
fix: fall back across Spotify cover CDN hosts

### DIFF
--- a/downtify/downloader.py
+++ b/downtify/downloader.py
@@ -1724,13 +1724,21 @@ class Downloader:
 def _download_cover(url: str) -> Optional[bytes]:
     if not url:
         return None
-    try:
-        response = requests.get(url, timeout=15)
-        response.raise_for_status()
-    except Exception:
-        logger.opt(exception=True).warning('Failed to fetch cover art {}', url)
-        return None
-    return response.content
+    candidates = spotify_mod.spotify_cover_url_candidates(url)
+    last_exc: Optional[Exception] = None
+    for candidate in candidates:
+        try:
+            response = requests.get(candidate, timeout=15)
+            response.raise_for_status()
+        except Exception as exc:
+            last_exc = exc
+            logger.debug('Cover art candidate failed {}: {}', candidate, exc)
+            continue
+        if candidate != candidates[0]:
+            logger.info('Fetched cover art via fallback CDN {}', candidate)
+        return response.content
+    logger.warning('Failed to fetch cover art {}: {}', url, last_exc)
+    return None
 
 
 def _album_track_index_for_tags(

--- a/downtify/spotify.py
+++ b/downtify/spotify.py
@@ -11,11 +11,32 @@ import json
 import re
 import time
 from typing import Any, Optional
+from urllib.parse import urlparse, urlunparse
 
 import requests
 from loguru import logger
 
 from .telemetry import json_log_blob, redact_sensitive_mapping
+
+# Spotify still emits ``i.scdn.co`` (and related) image hosts in embed /
+# GraphQL payloads, but those names are NXDOMAIN. Same ``/image/<id>`` paths
+# are served from the public spotifycdn edges — try Fastly then Akamai.
+_SPOTIFY_IMAGE_CDN_NETLOCS = (
+    'image-cdn-fa.spotifycdn.com',
+    'image-cdn-ak.spotifycdn.com',
+)
+_SPOTIFY_IMAGE_CDN_NETLOC = _SPOTIFY_IMAGE_CDN_NETLOCS[0]
+_DEAD_SCDN_IMAGE_HOSTS = frozenset({
+    'i.scdn.co',
+    'mosaic.scdn.co',
+    'lineup-images.scdn.co',
+    'charts-images.scdn.co',
+    'seeded-session-images.scdn.co',
+    'thisis-images.scdn.co',
+    'newjams-images.scdn.co',
+    'daily-mix.scdn.co',
+    'mix-images.scdn.co',
+})
 
 SPOTIFY_URL_RE = re.compile(
     r'(?:https?://)?(?:open\.)?spotify\.com/'
@@ -202,6 +223,49 @@ def _embed_row_track(item: dict[str, Any]) -> Optional[dict[str, Any]]:
     return item if isinstance(item, dict) else None
 
 
+def normalize_spotify_cover_url(url: str) -> str:
+    """Rewrite dead ``*.scdn.co`` cover hosts onto the primary spotifycdn edge.
+
+    Preview audio (``p.scdn.co``) is left untouched. Prefer
+    ``spotify_cover_url_candidates`` when fetching so alternate CDNs are tried.
+    """
+    if not url:
+        return ''
+    parsed = urlparse(url.strip())
+    host = (parsed.hostname or '').lower()
+    if host not in _DEAD_SCDN_IMAGE_HOSTS:
+        return url
+    if not parsed.path.startswith('/image/'):
+        return url
+    return urlunparse(
+        parsed._replace(scheme='https', netloc=_SPOTIFY_IMAGE_CDN_NETLOC)
+    )
+
+
+def spotify_cover_url_candidates(url: str) -> list[str]:
+    """Ordered cover URLs to try: primary host, then alternate spotifycdn edges."""
+    if not url:
+        return []
+    primary = normalize_spotify_cover_url(url)
+    parsed = urlparse(primary.strip())
+    path = parsed.path or ''
+    if not path.startswith('/image/'):
+        return [primary]
+    host = (parsed.hostname or '').lower()
+    ordered_hosts: list[str] = []
+    if host in _SPOTIFY_IMAGE_CDN_NETLOCS:
+        ordered_hosts.append(host)
+    for netloc in _SPOTIFY_IMAGE_CDN_NETLOCS:
+        if netloc not in ordered_hosts:
+            ordered_hosts.append(netloc)
+    out: list[str] = []
+    for netloc in ordered_hosts:
+        candidate = urlunparse(parsed._replace(scheme='https', netloc=netloc))
+        if candidate not in out:
+            out.append(candidate)
+    return out
+
+
 def _largest_image(sources: list[dict[str, Any]]) -> str:
     if not sources:
         return ''
@@ -209,7 +273,7 @@ def _largest_image(sources: list[dict[str, Any]]) -> str:
     if not sized:
         return ''
     sized.sort(key=lambda s: int(s.get('width') or 0), reverse=True)
-    return sized[0]['url']
+    return normalize_spotify_cover_url(sized[0]['url'])
 
 
 def _cover_url(entity: dict[str, Any]) -> str:

--- a/tests/test_spotify_url.py
+++ b/tests/test_spotify_url.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
-import pytest
+from unittest.mock import MagicMock
 
-from downtify.spotify import parse_spotify_url
+import pytest
+import requests
+
+from downtify.downloader import _download_cover
+from downtify.spotify import (
+    _largest_image,
+    normalize_spotify_cover_url,
+    parse_spotify_url,
+    spotify_cover_url_candidates,
+)
 
 # ── valid URLs ────────────────────────────────────────────────────────────────
 
@@ -124,3 +133,74 @@ def test_parse_id_is_alphanumeric(url):
     assert result is not None
     kind, sid = result
     assert sid.isalnum()
+
+
+def test_normalize_spotify_cover_url_rewrites_dead_scdn_host():
+    image_id = 'ab67616d0000b2739bbb6c626af68e56023c777a'
+    assert normalize_spotify_cover_url(
+        f'https://i.scdn.co/image/{image_id}'
+    ) == (f'https://image-cdn-fa.spotifycdn.com/image/{image_id}')
+
+
+def test_normalize_spotify_cover_url_keeps_working_cdn():
+    url = (
+        'https://image-cdn-fa.spotifycdn.com/image/'
+        'ab67616d0000b2739bbb6c626af68e56023c777a'
+    )
+    assert normalize_spotify_cover_url(url) == url
+
+
+def test_normalize_spotify_cover_url_leaves_preview_host():
+    url = 'https://p.scdn.co/mp3-preview/deadbeef'
+    assert normalize_spotify_cover_url(url) == url
+
+
+def test_largest_image_rewrites_scdn_cover():
+    image_id = 'ab67616d0000b2739bbb6c626af68e56023c777a'
+    out = _largest_image([
+        {'url': f'https://i.scdn.co/image/{image_id}', 'width': 640},
+        {
+            'url': (f'https://image-cdn-fa.spotifycdn.com/image/{image_id}'),
+            'width': 300,
+        },
+    ])
+    assert out == f'https://image-cdn-fa.spotifycdn.com/image/{image_id}'
+
+
+def test_spotify_cover_url_candidates_fallbacks():
+    image_id = 'ab67616d0000b2739bbb6c626af68e56023c777a'
+    candidates = spotify_cover_url_candidates(
+        f'https://i.scdn.co/image/{image_id}'
+    )
+    assert candidates == [
+        f'https://image-cdn-fa.spotifycdn.com/image/{image_id}',
+        f'https://image-cdn-ak.spotifycdn.com/image/{image_id}',
+    ]
+
+
+def test_spotify_cover_url_candidates_prefers_existing_akamai():
+    image_id = 'ab67616d0000b2739bbb6c626af68e56023c777a'
+    ak = f'https://image-cdn-ak.spotifycdn.com/image/{image_id}'
+    candidates = spotify_cover_url_candidates(ak)
+    assert candidates[0] == ak
+    assert 'image-cdn-fa.spotifycdn.com' in candidates[1]
+
+
+def test_download_cover_falls_back_to_second_cdn(monkeypatch):
+    image_id = 'ab67616d0000b2739bbb6c626af68e56023c777a'
+    calls: list[str] = []
+
+    def fake_get(url: str, timeout: int = 15):
+        calls.append(url)
+        if 'image-cdn-fa' in url:
+            raise requests.ConnectionError('fa down')
+        resp = MagicMock()
+        resp.content = b'jpeg'
+        resp.raise_for_status.return_value = None
+        return resp
+
+    monkeypatch.setattr('downtify.downloader.requests.get', fake_get)
+    assert _download_cover(f'https://i.scdn.co/image/{image_id}') == b'jpeg'
+    assert len(calls) == 2
+    assert 'image-cdn-fa.spotifycdn.com' in calls[0]
+    assert 'image-cdn-ak.spotifycdn.com' in calls[1]


### PR DESCRIPTION
## Summary
- Rewrite dead `i.scdn.co` (and related) cover URLs onto working `spotifycdn` hosts — `i.scdn.co` is NXDOMAIN worldwide.
- When fetching cover art, try `image-cdn-fa.spotifycdn.com` then `image-cdn-ak.spotifycdn.com` before giving up.
- Soften cover-fetch failure logging (no full traceback on DNS/connection errors).

## Test plan
- [ ] Unit tests for URL rewrite + CDN candidate order + download fallback (`tests/test_spotify_url.py`)
- [ ] Download a Spotify track whose metadata still has an `i.scdn.co` cover URL and confirm art embeds
- [ ] Confirm warning only appears if both CDN edges fail

Made with [Cursor](https://cursor.com)