### PR TITLE
fix: refresh playlists after retry-failed downloads

### DIFF
--- a/downtify/api.py
+++ b/downtify/api.py
@@ -1266,6 +1266,21 @@ async def _run_download(  # noqa: PLR0914
             'status': 'done',
             'filename': existing,
         })
+        pl_name = playlist_name
+        pl_id = spotify_playlist_id
+        order = track_order
+        affected = await loop.run_in_executor(
+            None,
+            lambda: _register_download_playlists_on_disk(
+                song,
+                existing,
+                playlist_name=pl_name,
+                spotify_playlist_id=pl_id,
+                track_order=order,
+            ),
+        )
+        if refresh_playlists and affected:
+            await _schedule_playlist_refresh_after_download(affected)
         return existing
 
     _TERMINAL_JOB_STATUSES = frozenset({'done', 'error'})
@@ -2956,6 +2971,52 @@ def clear_completed_queue() -> dict:
     return {'removed': _clear_completed_jobs()}
 
 
+async def _retry_failed_downloads(
+    retries: list[tuple[str, dict[str, Any]]],
+) -> set[str]:
+    """Re-run errored jobs; register catalog then refresh playlists once."""
+
+    async def _retry_one(song_id: str, song: dict[str, Any]) -> set[str]:
+        pl_ctx = _playlist_context_from_hints(song)
+        primary = pl_ctx.get('playlist_name')
+        try:
+            filename = await _run_download(
+                song,
+                song_id,
+                subdir=pl_ctx.get('subdir'),
+                playlist_name=primary,
+                spotify_playlist_id=pl_ctx.get('spotify_playlist_id'),
+                track_order=int(pl_ctx.get('track_order') or 0),
+                refresh_playlists=False,
+            )
+        except Exception:
+            logger.opt(exception=True).debug(
+                'retry failed download crashed for {}', song_id
+            )
+            return set()
+        if not filename:
+            return set()
+        return _playlists_for_successful_download(
+            song, primary_playlist=primary
+        )
+
+    results = await asyncio.gather(
+        *[_retry_one(song_id, song) for song_id, song in retries],
+        return_exceptions=False,
+    )
+    affected: set[str] = set()
+    for names in results:
+        affected.update(names)
+    if affected:
+        await _schedule_playlist_refresh_after_download(affected)
+    invalidate_playlist_batch_reports_cache()
+    await state.connections.broadcast({
+        'status': 'playlist_batches_changed',
+        'queue_pruned': 0,
+    })
+    return affected
+
+
 @router.post('/api/queue/retry-failed')
 async def retry_failed_queue_endpoint() -> dict[str, Any]:
     """Re-queue errored jobs and process them under the parallel limiter."""
@@ -2991,30 +3052,7 @@ async def retry_failed_queue_endpoint() -> dict[str, Any]:
             'status': 'queued',
         })
 
-    async def _retry_one(song_id: str, song: dict[str, Any]) -> None:
-        pl_ctx = _playlist_context_from_hints(song)
-        try:
-            await _run_download(
-                song,
-                song_id,
-                subdir=pl_ctx.get('subdir'),
-                playlist_name=pl_ctx.get('playlist_name'),
-                spotify_playlist_id=pl_ctx.get('spotify_playlist_id'),
-                track_order=int(pl_ctx.get('track_order') or 0),
-                refresh_playlists=False,
-            )
-        except Exception:
-            logger.opt(exception=True).debug(
-                'retry failed download crashed for {}', song_id
-            )
-
-    async def _run_retries() -> None:
-        await asyncio.gather(
-            *[_retry_one(song_id, song) for song_id, song in retries],
-            return_exceptions=False,
-        )
-
-    asyncio.create_task(_run_retries())
+    asyncio.create_task(_retry_failed_downloads(retries))
     return {
         'count': len(retries),
         'job_ids': [song_id for song_id, _ in retries],

--- a/tests/test_api_queue.py
+++ b/tests/test_api_queue.py
@@ -232,3 +232,115 @@ def test_retry_failed_queue_requeues_only_errors():
         api.state.downloader = prev_downloader
         api.state.connections = prev_connections
         api._run_download = prev_run_download
+
+
+def test_retry_failed_downloads_refreshes_playlists():
+    api.state.download_jobs.clear()
+    prev_downloader = api.state.downloader
+    prev_connections = api.state.connections
+    prev_run_download = api._run_download
+    api.state.downloader = object()
+    api.state.connections = AsyncMock()
+    scheduled: list[set[str]] = []
+    try:
+        song = {
+            'song_id': 'err-1',
+            'name': 'Fail',
+            'downtify_playlist_name': 'My Mix',
+        }
+        err_id = api._register_job(song, status='error')
+
+        async def _ok_download(_song, _song_id, **kwargs):
+            assert kwargs.get('refresh_playlists') is False
+            assert kwargs.get('playlist_name') == 'My Mix'
+            return 'track.mp3'
+
+        async def _schedule(names: set[str]) -> None:
+            scheduled.append(set(names))
+
+        api._run_download = _ok_download  # type: ignore[method-assign]
+
+        with (
+            patch.object(
+                api,
+                '_playlist_context_from_hints',
+                return_value={
+                    'playlist_name': 'My Mix',
+                    'spotify_playlist_id': 'pl123',
+                    'track_order': 2,
+                    'subdir': 'My Mix',
+                },
+            ),
+            patch.object(
+                api,
+                '_playlists_for_successful_download',
+                return_value={'My Mix', 'Other'},
+            ),
+            patch.object(
+                api,
+                '_schedule_playlist_refresh_after_download',
+                side_effect=_schedule,
+            ),
+            patch.object(api, 'invalidate_playlist_batch_reports_cache'),
+        ):
+            affected = asyncio.run(
+                api._retry_failed_downloads([(err_id, song)])
+            )
+
+        assert affected == {'My Mix', 'Other'}
+        assert scheduled == [{'My Mix', 'Other'}]
+        api.state.connections.broadcast.assert_awaited_with({
+            'status': 'playlist_batches_changed',
+            'queue_pruned': 0,
+        })
+    finally:
+        api.state.download_jobs.clear()
+        api.state.downloader = prev_downloader
+        api.state.connections = prev_connections
+        api._run_download = prev_run_download
+
+
+def test_retry_failed_downloads_skips_refresh_when_nothing_succeeds():
+    api.state.download_jobs.clear()
+    prev_downloader = api.state.downloader
+    prev_connections = api.state.connections
+    prev_run_download = api._run_download
+    api.state.downloader = object()
+    api.state.connections = AsyncMock()
+    try:
+        song = {'song_id': 'err-1', 'name': 'Fail'}
+        err_id = api._register_job(song, status='error')
+
+        async def _fail_download(*_args, **_kwargs):
+            return None
+
+        api._run_download = _fail_download  # type: ignore[method-assign]
+
+        with (
+            patch.object(
+                api,
+                '_playlist_context_from_hints',
+                return_value={},
+            ),
+            patch.object(
+                api,
+                '_schedule_playlist_refresh_after_download',
+                new_callable=AsyncMock,
+            ) as schedule,
+            patch.object(api, 'invalidate_playlist_batch_reports_cache'),
+        ):
+            affected = asyncio.run(
+                api._retry_failed_downloads([(err_id, song)])
+            )
+
+        assert affected == set()
+        schedule.assert_not_awaited()
+        api.state.connections.broadcast.assert_awaited_with({
+            'status': 'playlist_batches_changed',
+            'queue_pruned': 0,
+        })
+    finally:
+        api.state.download_jobs.clear()
+        api.state.downloader = prev_downloader
+        api.state.connections = prev_connections
+        api._run_download = prev_run_download


### PR DESCRIPTION
## Summary
- Retry-failed was calling `_run_download(..., refresh_playlists=False)` without the end-of-batch M3U/Navidrome refresh that normal playlist downloads run.
- After retries finish, aggregate affected playlists, schedule one refresh, and broadcast `playlist_batches_changed` so the UI updates.
- Already-on-disk skips now register the track into playlists (and refresh when requested).

## Test plan
- [ ] Queue a playlist download with at least one failed track, then use **Retry failed** on `/download`
- [ ] Confirm retried tracks appear in the playlist catalog / M3U
- [ ] Confirm incomplete-playlists UI refreshes after retries complete
- [ ] Confirm already-on-disk retries still join the playlist
- [ ] `uv run pytest tests/test_api_queue.py -x -q`


Made with [Cursor](https://cursor.com)