### PR TITLE
chore: sync requirements.txt after Dependabot uv bumps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ anyio==4.14.2
     # via starlette
 certifi==2026.7.22
     # via requests
-charset-normalizer==3.4.9
+charset-normalizer==3.5.1
     # via requests
 click==8.4.2
     # via uvicorn
@@ -22,7 +22,7 @@ fastapi==0.141.1
     # via downtify
 h11==0.16.0
     # via uvicorn
-idna==3.18
+idna==3.19
     # via
     #   anyio
     #   requests
@@ -36,7 +36,7 @@ pydantic==2.13.4
     # via fastapi
 pydantic-core==2.46.4
     # via pydantic
-python-dotenv==1.2.2
+python-dotenv==1.2.3
     # via load-dotenv
 python-multipart==0.0.32
     # via downtify
@@ -56,13 +56,13 @@ typing-extensions==4.16.0
     #   starlette
     #   typing-inspection
     #   uvicorn
-typing-inspection==0.4.2
+typing-inspection==0.4.4
     # via
     #   fastapi
     #   pydantic
 urllib3==2.7.0
     # via requests
-uvicorn==0.52.1
+uvicorn==0.52.4
     # via downtify
 websockets==16.1.1 ; python_full_version < '3.11'
     # via downtify
@@ -70,7 +70,7 @@ websockets==17.0.1 ; python_full_version >= '3.11'
     # via downtify
 win32-setctime==1.2.0 ; sys_platform == 'win32'
     # via loguru
-yt-dlp==2026.7.4
+yt-dlp==2026.8.19
     # via downtify
 ytmusicapi==1.12.2
     # via downtify


### PR DESCRIPTION
## Summary
- Regenerates `requirements.txt` from `uv.lock` after merging #109 (and co-bumped uvicorn/ruff/zensical).
- Unblocks Docker: the image installs via `pip install -r requirements.txt`, so lockfile-only Dependabot merges left the container on `uvicorn==0.52.1` / `yt-dlp==2026.7.4`.

## Test plan
- [ ] Confirm `requirements.txt` pins `uvicorn==0.52.4` and `yt-dlp==2026.8.19`
- [ ] CI Test workflow green
- [ ] After merge, Docker rebuild picks up the new pins (no need to change Dockerfile)


Made with [Cursor](https://cursor.com)